### PR TITLE
added the autoload.php step in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ And then run the vendors install command:
 
     $ ./bin/vendors install
 
+Ensure the Liip namespace can be loaded by updating your autoload.php:
+
+    $loader->registerNamespaces(array(
+        ...
+        'Liip'             => __DIR__.'/../vendor/bundles',
+        ...
+    ));
+
 Then register the bundle in the `AppKernel.php` file:
 
     public function registerBundles()


### PR DESCRIPTION
The step to add the Liip namespace to autoload.php was missing from the README, I've added it
