### PR TITLE
Added Symfony Security Advisory Check

### DIFF
--- a/Check/SymfonySecurityAdvisory.php
+++ b/Check/SymfonySecurityAdvisory.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Liip\MonitorBundle\Check;
+
+use Exception;
+use Liip\Monitor\Check\Check;
+use Liip\Monitor\Result\CheckResult;
+use Guzzle\Http\Client;
+
+/**
+ * Checks installed dependencies against Symfony Security Advisory database.
+ *
+ * Add this to your config.yml
+ *
+ *     monitor.check.symfony_security_advisory:
+ *         class: Liip\MonitorBundle\Check\SymfonySecurityAdvisory
+ *         arguments:
+ *             - %kernel.root_dir%
+ *         tags:
+ *             - { name: liip_monitor.check }
+ *
+ * @author Baldur Rensch <brensch@gmail.com>
+ */
+class SymfonySecurityAdvisoryCheck extends Check
+{
+    /**
+     * @var string
+     */
+    protected $kernelRootDir;
+
+    /**
+     * Construct.
+     *
+     * @param string $kernelRootDir
+     */
+    public function __construct($kernelRootDir)
+    {
+        $this->kernelRootDir = $kernelRootDir;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function check()
+    {
+        try {
+            $advisories = $this->checkSymfonyAdvisories();
+            if (empty($advisories)) {
+                $result = $this->buildResult('OK', CheckResult::OK);
+            } else {
+                $result = $this->buildResult('Advisories for ' . count($advisories) . ' packages', CheckResult::WARNING);
+            }
+        } catch (Exception $e) {
+            $result = $this->buildResult($e->getMessage(), CheckResult::UNKNOWN);
+        }
+
+        return $result;
+    }
+
+    private function checkSymfonyAdvisories()
+    {
+        $fileName = $this->kernelRootDir. '/../composer.lock';
+        if (!file_exists($fileName)) {
+            throw new Exception("No composer lock file found");
+        }
+
+        $client = new Client('https://security.sensiolabs.org');
+
+        $request = $client->post(
+            'check_lock',
+            array('Accept' => 'application/json'),
+            array('lock' => '@' . $fileName),
+        );
+
+        $response = $request->send();
+        $json = $response->json();
+
+        return $json;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'Symfony security advisory';
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": ">=5.3.2",
         "liip/monitor": "0.5.*",
-        "symfony/framework-bundle": ">2.0,<2.3-dev"
+        "symfony/framework-bundle": ">2.0,<2.3-dev",
+        "guzzle/guzzle": "3.2.*"
     },
     "suggest": {
         "sensio/distribution-bundle": "To be able to use the composer ScriptHandler"


### PR DESCRIPTION
This adds a check against the Symfony Security Advisory Database (https://security.sensiolabs.org/). 

The only downside is that it will require a library for HTTP requests (I chose Guzzle). We could also put it into the recommended section.
