### PR TITLE
Make 'error_codes' required for 'custom_error_pages'

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -55,6 +55,8 @@ class Configuration implements ConfigurationInterface
                         ->arrayNode('custom_error_pages')
                             ->children()
                                 ->arrayNode('error_codes')
+                                    ->isRequired()
+                                    ->requiresAtLeastOneElement()
                                     ->prototype('scalar')->end()
                                 ->end()
                                 ->scalarNode('path')->defaultValue('%kernel.root_dir%')->end()


### PR DESCRIPTION
Running this check without any error codes defined is useless and misleading.

In my case it made me think that the check was broken in 2.2 due to slightly different handling of custom error pages, so https://github.com/liip/LiipMonitorBundle/issues/27 could have been avoided.
