### PR TITLE
HealthCheckCommand closing tag on UNKNOWN error

### DIFF
--- a/Command/HealthCheckCommand.php
+++ b/Command/HealthCheckCommand.php
@@ -61,7 +61,7 @@ class HealthCheckCommand extends ContainerAwareCommand
                     break;
 
                 case CheckResult::UNKNOWN:
-                    $output->writeln(sprintf('<error>UNKNOWN<error> %s', $msg));
+                    $output->writeln(sprintf('<error>UNKNOWN</error> %s', $msg));
                     break;
             }
         }


### PR DESCRIPTION
When displaying status of a health check on unknown type, message was invalid.
