### PR TITLE
Improved the DBAL check dependency

### DIFF
--- a/Check/DoctrineDbal.php
+++ b/Check/DoctrineDbal.php
@@ -2,7 +2,7 @@
 
 namespace Liip\MonitorBundle\Check;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Persistence\ConnectionRegistry;
 use ZendDiagnostics\Check\AbstractCheck;
 use ZendDiagnostics\Result\Success;
 
@@ -11,9 +11,9 @@ class DoctrineDbal extends AbstractCheck
     protected $manager;
     protected $connectionName;
 
-    public function __construct(ManagerRegistry $manager, $connectionName)
+    public function __construct(ConnectionRegistry $registry, $connectionName = null)
     {
-        $this->manager = $manager;
+        $this->manager = $registry;
         $this->connectionName = $connectionName;
     }
 


### PR DESCRIPTION
The check only accesses the method of the ConnectionRegistry interface, so it does not need to depend on the bigger ManagerRegistry interface.

I also renamed the argument to be more meaningful (I haven't removed the property as it would be a BC break for child classes).
I also made the connection name default to `null` (which means using the default connection), which makes it easier to use.
