### PR TITLE
variable expansion does not work in cache directories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ before_script:
 
 cache:
   directories:
-    - $COMPOSER_CACHE_DIR
+    - /home/travis/.composer/cache


### PR DESCRIPTION
Travis confirmed that variable expansion doesn't work in cache directories yet.
https://github.com/travis-ci/travis-ci/issues/2153

The caching won't start working until this is merged to master.
