### PR TITLE
Added return statement to the HealthCheckCommand

### DIFF
--- a/Command/HealthCheckCommand.php
+++ b/Command/HealthCheckCommand.php
@@ -43,6 +43,6 @@ class HealthCheckCommand extends ContainerAwareCommand
             $output->writeln('<error>No checks configured.</error>');
         }
 
-        $runner->run($checkName);
+        return $runner->run($checkName)->getFailureCount() ? 1 : 0;
     }
 }


### PR DESCRIPTION
Exit code was '0' even when check fails
