### PR TITLE
ScriptHandler: update type of method getOptions() argument | fixes #86

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -1,6 +1,7 @@
 <?php
 namespace Liip\MonitorBundle\Composer;
 
+use Composer\Script\CommandEvent;
 use Sensio\Bundle\DistributionBundle\Composer\ScriptHandler as BaseHandler;
 
 /**
@@ -10,7 +11,7 @@ use Sensio\Bundle\DistributionBundle\Composer\ScriptHandler as BaseHandler;
  */
 class ScriptHandler extends BaseHandler
 {
-    public static function checkHealth($event)
+    public static function checkHealth(CommandEvent $event)
     {
         $options = self::getOptions($event);
 


### PR DESCRIPTION
Argument 1 passed to ScriptHandler::getOptions() must be an instance of
Composer\Script\CommandEvent, instance of Composer\Script\Event given