### PR TITLE
Add AdditionalReporterCompilerPass to container on bundle build

### DIFF
--- a/LiipMonitorBundle.php
+++ b/LiipMonitorBundle.php
@@ -2,6 +2,7 @@
 
 namespace Liip\MonitorBundle;
 
+use Liip\MonitorBundle\DependencyInjection\Compiler\AdditionalReporterCompilerPass;
 use Liip\MonitorBundle\DependencyInjection\Compiler\CheckCollectionTagCompilerPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -13,5 +14,6 @@ class LiipMonitorBundle extends Bundle
     {
         $container->addCompilerPass(new CheckTagCompilerPass());
         $container->addCompilerPass(new CheckCollectionTagCompilerPass());
+        $container->addCompilerPass(new AdditionalReporterCompilerPass());
     }
 }

--- a/Tests/LiipMonitorBundleTest.php
+++ b/Tests/LiipMonitorBundleTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Liip\MonitorBundle\Tests;
+
+use Liip\MonitorBundle\LiipMonitorBundle;
+
+/**
+ * Liip\MonitorBundle\Tests\LiipMonitorBundleTest
+ */
+class LiipMonitorBundleTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $container;
+
+    /**
+     * @var LiipMonitorBundle
+     */
+    protected $bundle;
+
+    public function testBuildWithCompilerPasses()
+    {
+        $compilerPasses = array(
+            'Liip\MonitorBundle\DependencyInjection\Compiler\CheckTagCompilerPass' => true,
+            'Liip\MonitorBundle\DependencyInjection\Compiler\CheckCollectionTagCompilerPass' => true,
+            'Liip\MonitorBundle\DependencyInjection\Compiler\AdditionalReporterCompilerPass' => true,
+        );
+
+        $this->container->expects($this->exactly(count($compilerPasses)))
+            ->method('addCompilerPass')
+            ->with($this->isInstanceOf('Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface'))
+            ->willReturnCallback(
+                function ($compilerPass) use (&$compilerPasses) {
+                    $class = get_class($compilerPass);
+                    $this->assertArrayHasKey($class, $compilerPasses);
+                    unset($compilerPasses[$class]);
+                }
+            );
+
+        $this->bundle->build($this->container);
+        $this->assertEmpty($compilerPasses);
+    }
+
+    /**
+     * Sets up test
+     */
+    protected function setUp()
+    {
+        $this->container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->bundle = new LiipMonitorBundle();
+    }
+}

--- a/Tests/LiipMonitorBundleTest.php
+++ b/Tests/LiipMonitorBundleTest.php
@@ -19,6 +19,9 @@ class LiipMonitorBundleTest extends \PHPUnit_Framework_TestCase
      */
     protected $bundle;
 
+    /**
+     * Test bundle build to add all required compiler passes
+     */
     public function testBuildWithCompilerPasses()
     {
         $compilerPasses = array(
@@ -33,7 +36,6 @@ class LiipMonitorBundleTest extends \PHPUnit_Framework_TestCase
             ->willReturnCallback(
                 function ($compilerPass) use (&$compilerPasses) {
                     $class = get_class($compilerPass);
-                    $this->assertArrayHasKey($class, $compilerPasses);
                     unset($compilerPasses[$class]);
                 }
             );


### PR DESCRIPTION
Additional reporters are well documented, but compiler pass is not loaded. Am I missing something?