### PR TITLE
Nagios support for monitor:health

### DIFF
--- a/Command/HealthCheckCommand.php
+++ b/Command/HealthCheckCommand.php
@@ -64,11 +64,9 @@ class HealthCheckCommand extends ContainerAwareCommand
                 return 2;
             } elseif ($results->getWarningCount()) {
                 return 1;
-            } else {
-                return 0; // We may have some skipped tests although
             }
-        } else {
-            return $results->getFailureCount() ? 1 : 0;
         }
+        
+        return $results->getFailureCount() ? 1 : 0;
     }
 }

--- a/Command/HealthCheckCommand.php
+++ b/Command/HealthCheckCommand.php
@@ -3,6 +3,7 @@
 namespace Liip\MonitorBundle\Command;
 
 use Liip\MonitorBundle\Helper\ConsoleReporter;
+use Liip\MonitorBundle\Helper\RawConsoleReporter;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -28,6 +29,12 @@ class HealthCheckCommand extends ContainerAwareCommand
                     InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                     'Additional reporters to run.',
                     array()
+                ),
+                new InputOption(
+                    'nagios',
+                    null,
+                    InputOption::VALUE_NONE,
+                    'Suitable for using as a nagios NRPE command.'
                 )
             ));
     }
@@ -36,13 +43,34 @@ class HealthCheckCommand extends ContainerAwareCommand
     {
         $checkName = $input->getArgument('checkName');
         $runner = $this->getContainer()->get('liip_monitor.runner');
-        $runner->addReporter(new ConsoleReporter($output));
+
+        if ($input->getOption('nagios')) {
+            $runner->addReporter(new RawConsoleReporter($output));
+        } else {
+            $runner->addReporter(new ConsoleReporter($output));
+        }
         $runner->useAdditionalReporters($input->getOption('reporter'));
 
         if (0 === count($runner->getChecks())) {
             $output->writeln('<error>No checks configured.</error>');
         }
 
-        return $runner->run($checkName)->getFailureCount() ? 1 : 0;
+        /** @var \ZendDiagnostics\Result\Collection $results */
+        $results = $runner->run($checkName);
+        if ($input->getOption('nagios')) {
+            if ($results->getUnknownCount()) {
+                $returnCode = 3;
+            } else if($results->getFailureCount()) {
+                $returnCode = 2;
+            } else if($results->getWarningCount()) {
+                $returnCode = 1;
+            } else {
+                $returnCode = 0; // We may have som skipped although
+            }
+        } else {
+            $returnCode = $results->getFailureCount() ? 1 : 0;
+        }
+
+        return $returnCode;
     }
 }

--- a/Command/HealthCheckCommand.php
+++ b/Command/HealthCheckCommand.php
@@ -59,18 +59,16 @@ class HealthCheckCommand extends ContainerAwareCommand
         $results = $runner->run($checkName);
         if ($input->getOption('nagios')) {
             if ($results->getUnknownCount()) {
-                $returnCode = 3;
-            } else if($results->getFailureCount()) {
-                $returnCode = 2;
-            } else if($results->getWarningCount()) {
-                $returnCode = 1;
+                return 3;
+            } elseif ($results->getFailureCount()) {
+                return 2;
+            } elseif ($results->getWarningCount()) {
+                return 1;
             } else {
-                $returnCode = 0; // We may have som skipped although
+                return 0; // We may have some skipped tests although
             }
         } else {
-            $returnCode = $results->getFailureCount() ? 1 : 0;
+            return $results->getFailureCount() ? 1 : 0;
         }
-
-        return $returnCode;
     }
 }

--- a/Helper/RawConsoleReporter.php
+++ b/Helper/RawConsoleReporter.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Liip\MonitorBundle\Helper;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use ZendDiagnostics\Check\CheckInterface;
+use ZendDiagnostics\Result\ResultInterface;
+use ZendDiagnostics\Result\SkipInterface;
+use ZendDiagnostics\Result\SuccessInterface;
+use ZendDiagnostics\Result\WarningInterface;
+use ZendDiagnostics\Runner\Reporter\ReporterInterface;
+use ZendDiagnostics\Result\Collection as ResultsCollection;
+
+/**
+ * Like ConsoleReporter, but without coloration, and no message.
+ */
+class RawConsoleReporter implements ReporterInterface
+{
+    protected $output;
+
+    public function __construct(OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function onAfterRun(CheckInterface $check, ResultInterface $result, $checkAlias = null)
+    {
+        switch (true) {
+            case $result instanceof SuccessInterface:
+                $this->output->write('OK');
+                break;
+
+            case $result instanceof WarningInterface:
+                $this->output->write('WARNING');
+                break;
+
+            case $result instanceof SkipInterface:
+                $this->output->write('SKIP');
+                break;
+
+            default:
+                $this->output->write('FAIL');
+        }
+
+        $this->output->writeln(sprintf(' %s', $check->getLabel()));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function onStart(\ArrayObject $checks, $runnerConfig)
+    {
+        return;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function onBeforeRun(CheckInterface $check, $checkAlias = null)
+    {
+        return;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function onStop(ResultsCollection $results)
+    {
+        return;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function onFinish(ResultsCollection $results)
+    {
+        return;
+    }
+}


### PR DESCRIPTION
Add --nagios option to the monitor:health command, making it suitable to use with NRPE plugins.

```--nagios``` implies RawConsoleReporter (usual reporter without the coloring), and returnCodes following the NRPE norm (0: ok, 1: warning, 2:critical).