### PR TITLE
Fix deprecated routing patterns

### DIFF
--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -3,19 +3,19 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="liip_monitor_health_interface" pattern="/">
+    <route id="liip_monitor_health_interface" path="/">
         <default key="_controller">liip_monitor.health_controller:indexAction</default>
     </route>
-    <route id="liip_monitor_list_checks" pattern="/checks">
+    <route id="liip_monitor_list_checks" path="/checks">
         <default key="_controller">liip_monitor.health_controller:listAction</default>
     </route>
-    <route id="liip_monitor_run_all_checks_http_status" pattern="/http_status_checks">
+    <route id="liip_monitor_run_all_checks_http_status" path="/http_status_checks">
         <default key="_controller">liip_monitor.health_controller:runAllChecksHttpStatusAction</default>
     </route>
-    <route id="liip_monitor_run_all_checks" pattern="/run">
+    <route id="liip_monitor_run_all_checks" path="/run">
         <default key="_controller">liip_monitor.health_controller:runAllChecksAction</default>
     </route>
-    <route id="liip_monitor_run_single_check" pattern="/run/{checkId}">
+    <route id="liip_monitor_run_single_check" path="/run/{checkId}">
         <default key="_controller">liip_monitor.health_controller:runSingleCheckAction</default>
     </route>
 </routes>


### PR DESCRIPTION
As of Symfony 2.2, the route setting `pattern` has been replaced by `path`. As far as I know, all deprecation warnings should be gone now (tested with Symfony 2.7).

Details: [symfony/symfony#6738](https://github.com/symfony/symfony/pull/6738/files)