### PR TITLE
Issue 111 - add Nagios Performance Data to check Results

### DIFF
--- a/Command/HealthCheckCommand.php
+++ b/Command/HealthCheckCommand.php
@@ -39,16 +39,24 @@ class HealthCheckCommand extends ContainerAwareCommand
             ));
     }
 
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $checkName = $input->getArgument('checkName');
         $runner = $this->getContainer()->get('liip_monitor.runner');
 
         if ($input->getOption('nagios')) {
-            $runner->addReporter(new RawConsoleReporter($output));
+            $reporter = $this->getContainer()->get('liip_monitor.helper.raw_console_reporter');
         } else {
-            $runner->addReporter(new ConsoleReporter($output));
+            $reporter = $this->getContainer()->get('liip_monitor.helper.console_reporter');
         }
+
+        $runner->addReporter($reporter);
         $runner->useAdditionalReporters($input->getOption('reporter'));
 
         if (0 === count($runner->getChecks())) {

--- a/DependencyInjection/LiipMonitorExtension.php
+++ b/DependencyInjection/LiipMonitorExtension.php
@@ -19,6 +19,7 @@ class LiipMonitorExtension extends Extension
     {
         $loader =  new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('runner.xml');
+        $loader->load('helper.xml');
 
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/Helper/ConsoleReporter.php
+++ b/Helper/ConsoleReporter.php
@@ -2,6 +2,7 @@
 
 namespace Liip\MonitorBundle\Helper;
 
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use ZendDiagnostics\Check\CheckInterface;
 use ZendDiagnostics\Result\ResultInterface;
@@ -16,10 +17,19 @@ use ZendDiagnostics\Result\Collection as ResultsCollection;
  */
 class ConsoleReporter implements ReporterInterface
 {
+    /**
+     * @var OutputInterface
+     */
     protected $output;
 
-    public function __construct(OutputInterface $output)
+    /**
+     * @param OutputInterface $output
+     */
+    public function __construct(OutputInterface $output = null)
     {
+        if (is_null($output)) {
+            $output = new ConsoleOutput();
+        }
         $this->output = $output;
     }
 

--- a/Helper/RawConsoleReporter.php
+++ b/Helper/RawConsoleReporter.php
@@ -2,6 +2,7 @@
 
 namespace Liip\MonitorBundle\Helper;
 
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use ZendDiagnostics\Check\CheckInterface;
 use ZendDiagnostics\Result\ResultInterface;
@@ -16,10 +17,19 @@ use ZendDiagnostics\Result\Collection as ResultsCollection;
  */
 class RawConsoleReporter implements ReporterInterface
 {
+    /**
+     * @var OutputInterface
+     */
     protected $output;
 
-    public function __construct(OutputInterface $output)
+    /**
+     * @param OutputInterface $output
+     */
+    public function __construct(OutputInterface $output = null)
     {
+        if (is_null($output)) {
+            $output = new ConsoleOutput();
+        }
         $this->output = $output;
     }
 

--- a/Helper/RawConsoleReporter.php
+++ b/Helper/RawConsoleReporter.php
@@ -55,7 +55,17 @@ class RawConsoleReporter implements ReporterInterface
                 $this->output->write('FAIL');
         }
 
-        $this->output->writeln(sprintf(' %s', $check->getLabel()));
+        $performanceData = $this->getNagiosPerformanceData();
+
+        $this->output->writeln(sprintf(' %s', $check->getLabel() . $performanceData));
+    }
+
+    /**
+     * @return string
+     */
+    protected function getNagiosPerformanceData()
+    {
+        return '';
     }
 
     /**

--- a/Resources/config/helper.xml
+++ b/Resources/config/helper.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="liip_monitor.helper.raw_console_reporter.class">Liip\MonitorBundle\Helper\RawConsoleReporter</parameter>
+        <parameter key="liip_monitor.helper.console_reporter.class">Liip\MonitorBundle\Helper\ConsoleReporter</parameter>
+    </parameters>
+
+    <services>
+        <service id="liip_monitor.helper.raw_console_reporter" class="%liip_monitor.helper.raw_console_reporter.class%" />
+        <service id="liip_monitor.helper.console_reporter" class="%liip_monitor.helper.console_reporter.class%" />
+    </services>
+</container>


### PR DESCRIPTION
This PR references issue #111.

This implementation enables the possibility to extend the ```RawConsoleReporter``` and implement the protected method ```getNagiosPerformanceData```:
```
namespace Acme\AppBundle\Checks;

use Liip\MonitorBundle\Helper\RawConsoleReporter;
use ZendDiagnostics\Check\CheckInterface;

class MyPerformanceReporter extends RawConsoleReporter
{

    [...]

    /**
     * @return string
     */
    protected function getNagiosPerformanceData()
    {
        // calculate some fancy perfomance information
        return '';
    }

    [...]
}

```

The original reporter can be replaced via class-parameter: 
```
parameters:
    liip_monitor.helper.raw_console_reporter.class: Acme\AppBundle\Checks\MyPerformanceReporter
```

And the Result would be something like this:
```
OK Doctrine DBAL "default" connection|time=0.009594s;;;0.000000
```

For now that fits our purpose. A better solution would probably be, to let each check handle its own performancedata-output. That might be a more advanced solution. Maybe this should be configurable.