### PR TITLE
Fixed BC for missing method in sf ^3.0

### DIFF
--- a/Helper/PathHelper.php
+++ b/Helper/PathHelper.php
@@ -26,8 +26,18 @@ class PathHelper
     public function generateRoutes(array $routes)
     {
         $ret = array();
+
+        if (!method_exists($this->routerHelper, 'path')) {
+            // symfony 2.7 and lower don't have the path method, BC layer
+            foreach ($routes as $route => $params) {
+                $ret[] = sprintf('api.%s = "%s";', $route, $this->routerHelper->generate($route, $params));
+            }
+
+            return $ret;
+        }
+
         foreach ($routes as $route => $params) {
-            $ret[] = sprintf('api.%s = "%s";', $route, $this->routerHelper->generate($route, $params));
+            $ret[] = sprintf('api.%s = "%s";', $route, $this->routerHelper->path($route, $params));
         }
 
         return $ret;


### PR DESCRIPTION
In 3.0 the `generate()` method has been replaced by `path()` and `url()` to make them more consistent with their twig counterpart. Sadly this broke in 3.0. This BC layer will make sure it will work in all currently supported versions. 2.3 and 2.7 will use `generate` whereas 2.8 and higher will use `path`.

Minimal change required when 2.3 and 2.7 support drops.