### PR TITLE
Switch from deprecated CommandEvent to Event

### DIFF
--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -2,7 +2,7 @@
 
 namespace Liip\MonitorBundle\Composer;
 
-use Composer\Script\CommandEvent;
+use Composer\Script\Event;
 use Sensio\Bundle\DistributionBundle\Composer\ScriptHandler as BaseHandler;
 
 /**
@@ -11,7 +11,7 @@ use Sensio\Bundle\DistributionBundle\Composer\ScriptHandler as BaseHandler;
  */
 class ScriptHandler extends BaseHandler
 {
-    public static function checkHealth(CommandEvent $event)
+    public static function checkHealth(Event $event)
     {
         $options = self::getOptions($event);
 


### PR DESCRIPTION
This should fix #133. Not sure if this will cause issues in older versions of composer. If so, we can probably remove the typehint. I suggest we wait until we have people with issues before we do that.