### PR TITLE
Added fallback for undefined services of symfony3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+/Tests/app/cache
+/Tests/app/logs
 /vendor
 composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION=3.2
     - php: 5.4
-      env: COMPOSER_FLAGS="--prefer-lowest"
+      env: SYMFONY_VERSION=2.3;COMPOSER_FLAGS="--prefer-lowest"
 
 before_install:
   - if [[ $TRAVIS_PHP_VERSION != '7.0' && $TRAVIS_PHP_VERSION != '7.1' && $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-rm xdebug.ini; fi
@@ -39,7 +39,7 @@ before_install:
 
 install: composer update --prefer-source $COMPOSER_FLAGS
 
-script: phpunit --coverage-text
+script: vendor/bin/phpunit --coverage-text
 
 notifications:
   slack: liip:3QOs1QKt3aCFxpJvRzpJCbVZ

--- a/Helper/PathHelper.php
+++ b/Helper/PathHelper.php
@@ -10,12 +10,17 @@ class PathHelper
     protected $routerHelper;
 
     /**
-     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+     * @param ContainerInterface $container
      */
     public function __construct(ContainerInterface $container)
     {
-        $this->assetsHelper = $container->get('templating.helper.assets');
-        $this->routerHelper = $container->get('templating.helper.router');
+        // symfony3 does not define templating.helper.assets unless php templating is included
+        $this->assetsHelper = $container->has('templating.helper.assets') ?
+            $container->get('templating.helper.assets') : $container->get('assets.packages');
+
+        // symfony3 does not define templating.helper.router unless php templating is included
+        $this->routerHelper = $container->has('templating.helper.router') ?
+            $container->get('templating.helper.router') : $container->get('router');
     }
 
     /**

--- a/Tests/DependencyInjection/LiipMonitorExtensionTest.php
+++ b/Tests/DependencyInjection/LiipMonitorExtensionTest.php
@@ -201,7 +201,8 @@ class LiipMonitorExtensionTest extends AbstractExtensionTestCase
 
     protected function compile()
     {
-        $this->container->set('doctrine', $this->getMock('Doctrine\Common\Persistence\ConnectionRegistry'));
+        $doctrineMock = $this->getMockBuilder('Doctrine\Common\Persistence\ConnectionRegistry')->getMock();
+        $this->container->set('doctrine', $doctrineMock);
         $this->container->addCompilerPass(new AddGroupsCompilerPass());
         $this->container->addCompilerPass(new GroupRunnersCompilerPass());
         $this->container->addCompilerPass(new CheckTagCompilerPass());

--- a/Tests/Helper/PathHelperTest.php
+++ b/Tests/Helper/PathHelperTest.php
@@ -1,0 +1,29 @@
+<?php
+namespace Liip\MonitorBundle\Tests\Helper;
+
+use Liip\MonitorBundle\Helper\PathHelper;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpKernel\Kernel;
+
+class PathHelperTest extends WebTestCase
+{
+    public function testGenerateRoutes()
+    {
+        if (Kernel::MAJOR_VERSION === '2' && Kernel::MINOR_VERSION === '7') {
+            $environment = 'symfony27';
+        } else {
+            $environment = 'symfony' . Kernel::MAJOR_VERSION;
+        }
+
+        $client = static::createClient(array('environment' => $environment));
+
+        $container = $client->getContainer();
+
+        $pathHelper = new PathHelper($container);
+
+        // test route is defined in Tests/app/routing.yml
+        $routes = $pathHelper->generateRoutes(['test_route' => []]);
+
+        $this->assertEquals(['api.test_route = "/monitor";'], $routes);
+    }
+}

--- a/Tests/Helper/RunnerManagerTest.php
+++ b/Tests/Helper/RunnerManagerTest.php
@@ -44,7 +44,7 @@ class RunnerManagerTest extends \PHPUnit_Framework_TestCase
             ->with('liip_monitor.runner_'.($group ?: 'default'))
             ->willReturn(true);
 
-        $expectedResult = $this->getMock('Liip\MonitorBundle\Runner');
+        $expectedResult = $this->getMockBuilder('Liip\MonitorBundle\Runner')->getMock();
 
         $this->container
             ->expects($this->any())
@@ -78,8 +78,9 @@ class RunnerManagerTest extends \PHPUnit_Framework_TestCase
             ->with('liip_monitor.runners')
             ->willReturn(array('liip_monitor.runner_group_1', 'liip_monitor.runner_group_2'));
 
-        $runner1 = $this->getMock('Liip\MonitorBundle\Runner');
-        $runner2 = $this->getMock('Liip\MonitorBundle\Runner');
+        $runnerMockBuilder = $this->getMockBuilder('Liip\MonitorBundle\Runner');
+        $runner1 = $runnerMockBuilder->getMock();
+        $runner2 = $runnerMockBuilder->getMock();
         $this->container
             ->expects($this->exactly(2))
             ->method('get')
@@ -132,7 +133,7 @@ class RunnerManagerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
 
         $this->runnerManager = new RunnerManager($this->container);
     }

--- a/Tests/RunnerTest.php
+++ b/Tests/RunnerTest.php
@@ -46,6 +46,6 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
      */
     private function createMockReporter()
     {
-        return $this->getMock('ZendDiagnostics\Runner\Reporter\ReporterInterface');
+        return $this->getMockBuilder('ZendDiagnostics\Runner\Reporter\ReporterInterface')->getMock();
     }
 }

--- a/Tests/app/AppKernel.php
+++ b/Tests/app/AppKernel.php
@@ -1,0 +1,29 @@
+<?php
+
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Config\Loader\LoaderInterface;
+
+/**
+ * Class AppKernel
+ */
+class AppKernel extends Kernel
+{
+    /**
+     * @return array
+     */
+    public function registerBundles()
+    {
+        return [
+            new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new Symfony\Bundle\TwigBundle\TwigBundle(),
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(__DIR__ . '/config_' . $this->environment . '.yml');
+    }
+}

--- a/Tests/app/config_symfony2.yml
+++ b/Tests/app/config_symfony2.yml
@@ -1,0 +1,11 @@
+# symfony 2 config (requires assets_base_urls for testing)
+framework:
+    router:
+        resource: "%kernel.root_dir%/routing.yml"
+    secret:        test
+    templating:
+        engines: ['twig']
+        assets_base_urls: { http: ["http://testurl"], ssl: ["http://testurl"] }
+    test: ~
+    profiler:
+        collect: false

--- a/Tests/app/config_symfony27.yml
+++ b/Tests/app/config_symfony27.yml
@@ -1,0 +1,10 @@
+# symfony 2.7 config (no longer allows assets_base_urls)
+framework:
+    router:
+        resource: "%kernel.root_dir%/routing.yml"
+    secret:        test
+    templating:
+        engines: ['twig']
+    test: ~
+    profiler:
+        collect: false

--- a/Tests/app/config_symfony3.yml
+++ b/Tests/app/config_symfony3.yml
@@ -1,0 +1,11 @@
+# symfony 3 config (requires assets defined)
+framework:
+    router:
+        resource: "%kernel.root_dir%/routing.yml"
+    secret:        test
+    templating:
+        engines: ['twig']
+    test: ~
+    assets: ~
+    profiler:
+        collect: false

--- a/Tests/app/routing.yml
+++ b/Tests/app/routing.yml
@@ -1,0 +1,2 @@
+test_route:
+    path: "/monitor"

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,13 @@
         "symfony/expression-language": "~2.3|~3.0",
         "swiftmailer/swiftmailer": "~5.4",
         "doctrine/migrations": "~1.0",
-        "doctrine/doctrine-migrations-bundle": "~1.0"
+        "doctrine/doctrine-migrations-bundle": "~1.0",
+        "symfony/twig-bundle": "^2.0|^3.0",
+        "symfony/browser-kit": "^2.0|^3.0",
+        "symfony/asset": "^2.0|^3.0",
+        "symfony/templating": "^2.0|^3.0",
+        "phpunit/phpunit": "^4.8|^5.0",
+        "symfony/finder": "^2.0|^3.0"
     },
     "suggest": {
         "sensio/distribution-bundle": "To be able to use the composer ScriptHandler",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,10 @@
         </testsuite>
     </testsuites>
 
+    <php>
+        <server name="KERNEL_DIR" value="Tests/app" />
+    </php>
+
     <filter>
         <whitelist>
             <directory>./</directory>


### PR DESCRIPTION
- For issue #125 instead of PR #128 
- These services are undefined in Symfony 3 unless 'php' is added as a template engine as well.
- Brought phpunit in dev dependencies to solve compatibility issues with travis (installs v6 with php 7)
- Refactored getMock (which is deprecated in phpunit 5.3.0+) with mockbuilder calls. That will still work to allow removing phpunit 4 (required by old php versions 5.3, 5.4, 5.5) which are still in the matrix. I believe master will already prove broken if it gets retested by travis as is.
- Added functional test
- Added the lowest symfony version to the prefer-lowest step too

Not sure what's wrong with highlighting. The whole repository seems messed up.