### PR TITLE
Removed extra escaping where the param is defined already

### DIFF
--- a/Resources/config/checks/file_ini.xml
+++ b/Resources/config/checks/file_ini.xml
@@ -13,7 +13,7 @@
         <service id="liip_monitor.check.file_ini" public="false" class="%liip_monitor.check.file_ini.class%">
             <argument>%%liip_monitor.check.file_ini%%</argument>
             <call method="setLabel">
-                <argument>%%liip_monitor.check.file_ini.label%%</argument>
+                <argument>%liip_monitor.check.file_ini.label%</argument>
             </call>
             <tag name="liip_monitor.check" alias="file_ini" />
         </service>

--- a/Resources/config/checks/file_json.xml
+++ b/Resources/config/checks/file_json.xml
@@ -13,7 +13,7 @@
         <service id="liip_monitor.check.file_json" public="false" class="%liip_monitor.check.file_json.class%">
             <argument>%%liip_monitor.check.file_json%%</argument>
             <call method="setLabel">
-                <argument>%%liip_monitor.check.file_json.label%%</argument>
+                <argument>%liip_monitor.check.file_json.label%</argument>
             </call>
             <tag name="liip_monitor.check" alias="file_json" />
         </service>

--- a/Resources/config/checks/file_xml.xml
+++ b/Resources/config/checks/file_xml.xml
@@ -13,7 +13,7 @@
         <service id="liip_monitor.check.file_xml" public="false" class="%liip_monitor.check.file_xml.class%">
             <argument>%%liip_monitor.check.file_xml%%</argument>
             <call method="setLabel">
-                <argument>%%liip_monitor.check.file_xml.label%%</argument>
+                <argument>%liip_monitor.check.file_xml.label%</argument>
             </call>
             <tag name="liip_monitor.check" alias="file_xml" />
         </service>

--- a/Resources/config/checks/file_yaml.xml
+++ b/Resources/config/checks/file_yaml.xml
@@ -13,7 +13,7 @@
         <service id="liip_monitor.check.file_yaml" public="false" class="%liip_monitor.check.file_yaml.class%">
             <argument>%%liip_monitor.check.file_yaml%%</argument>
             <call method="setLabel">
-                <argument>%%liip_monitor.check.file_yaml.label%%</argument>
+                <argument>%liip_monitor.check.file_yaml.label%</argument>
             </call>
             <tag name="liip_monitor.check" alias="file_yaml" />
         </service>


### PR DESCRIPTION
The label is already defined at the top of the same xml file and right now it appears like this:

```json
{
    "checkName": "%liip_monitor.check.file_yaml.label%",
    "message": "All files are available and valid",
    "status": 0,
    "status_name": "check_result_ok",
    "service_id": "file_yaml"
}
```
