### PR TITLE
Added support for tag autoconfiguration

### DIFF
--- a/LiipMonitorBundle.php
+++ b/LiipMonitorBundle.php
@@ -5,15 +5,20 @@ namespace Liip\MonitorBundle;
 use Liip\MonitorBundle\DependencyInjection\Compiler\AddGroupsCompilerPass;
 use Liip\MonitorBundle\DependencyInjection\Compiler\AdditionalReporterCompilerPass;
 use Liip\MonitorBundle\DependencyInjection\Compiler\CheckCollectionTagCompilerPass;
-use Liip\MonitorBundle\DependencyInjection\Compiler\GroupRunnersCompilerPass;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Liip\MonitorBundle\DependencyInjection\Compiler\CheckTagCompilerPass;
+use Liip\MonitorBundle\DependencyInjection\Compiler\GroupRunnersCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class LiipMonitorBundle extends Bundle
 {
     public function build(ContainerBuilder $container)
     {
+        if (method_exists($container, 'registerForAutoconfiguration')) {
+            $container->registerForAutoconfiguration('ZendDiagnostics\Check\CheckInterface')
+                ->addTag('liip_monitor.check');
+        }
+
         $container->addCompilerPass(new AddGroupsCompilerPass());
         $container->addCompilerPass(new GroupRunnersCompilerPass());
         $container->addCompilerPass(new CheckTagCompilerPass());

--- a/Tests/LiipMonitorBundleTest.php
+++ b/Tests/LiipMonitorBundleTest.php
@@ -3,6 +3,7 @@
 namespace Liip\MonitorBundle\Tests;
 
 use Liip\MonitorBundle\LiipMonitorBundle;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 
 /**
  * Liip\MonitorBundle\Tests\LiipMonitorBundleTest.
@@ -42,8 +43,18 @@ class LiipMonitorBundleTest extends \PHPUnit_Framework_TestCase
                 }
             );
 
+        $definition = null;
+
+        if (method_exists('Symfony\Component\DependencyInjection\ContainerBuilder', 'registerForAutoconfiguration')) {
+            $this->container->method('registerForAutoconfiguration')->willReturn($definition = new ChildDefinition(''));
+        }
+
         $this->bundle->build($this->container);
         $this->assertEmpty($compilerPasses);
+
+        if ($definition) {
+            $this->assertTrue($definition->hasTag('liip_monitor.check'));
+        }
     }
 
     /**


### PR DESCRIPTION
With autoconfigure, you can automatically add tags based on an interface that should be applied. I've used the `CheckInterface` as this is also in the signature for the `addCheck` method. I've check if the alias is mandatory in my application, but it seems to work just fine with FQCN, note that this will be the "service_id".