### PR TITLE
fix symfony 4.0 requirement problem

### DIFF
--- a/Resources/config/runner.xml
+++ b/Resources/config/runner.xml
@@ -9,6 +9,6 @@
     </parameters>
 
     <services>
-        <service id="liip_monitor.runner" class="%liip_monitor.runner.class%" />
+        <service id="liip_monitor.runner" class="%liip_monitor.runner.class%" public="true" />
     </services>
 </container>

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
     "require": {
         "php": "^5.4|^7.0",
         "symfony/framework-bundle": "~2.7|~3.0|^4.0",
-        "zendframework/zenddiagnostics": "^1.0.2",
-        "symfony/symfony": "^4.0"
+        "zendframework/zenddiagnostics": "^1.0.2"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",


### PR DESCRIPTION
rm composer.lock || true
composer install --prefer-dist --optimize-autoloader --classmap-authoritative --no-interaction --no-progress --no-dev
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for system dev-symfony-upgrade -> satisfiable by system[dev-symfony-upgrade].
    - liip/monitor-bundle 2.6.0 requires symfony/symfony ^4.0 -> satisfiable by symfony/symfony[v4.0.0, v4.0.1].
    - don't install symfony/symfony v4.0.0|remove system dev-symfony-upgrade
    - don't install symfony/symfony v4.0.1|remove system dev-symfony-upgrade
    - Installation request for liip/monitor-bundle ~2.6.0 -> satisfiable by liip/monitor-bundle[2.6.0].
