### PR TITLE
Drop support for PHP 5.x and update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 dist: trusty
 group: edge
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
@@ -13,25 +12,18 @@ cache:
     - $HOME/.composer/cache/files
 
 env:
-  - SYMFONY_VERSION=2.7.*
+  - SYMFONY_VERSION=3.1.*
 
 matrix:
   include:
-    - php: 5.6
-      env: SYMFONY_VERSION=2.8.*
-    - php: 5.6
-      env: SYMFONY_VERSION=3.3.*
-    - php: 5.6
-      env: SYMFONY_VERSION=3.4.*
     - php: 7.1
       env: SYMFONY_VERSION=4.0.*
     - php: 7.2
-      env: SYMFONY_VERSION=4.0.*
-    - php: 5.6
-      env: SYMFONY_VERSION=2.7.*;COMPOSER_FLAGS="--prefer-lowest"
+      env: SYMFONY_VERSION=4.1.*
+    - php: 7.0
+      env: SYMFONY_VERSION=3.1.*;COMPOSER_FLAGS="--prefer-lowest"
 
 before_install:
-  - if [[ $TRAVIS_PHP_VERSION != '7.0' && $TRAVIS_PHP_VERSION != '7.1' && $TRAVIS_PHP_VERSION != '7.2' ]]; then phpenv config-rm xdebug.ini; fi
   - echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: php
-sudo: false
-
+sudo: required
+dist: trusty
+group: edge
 php:
+  - 5.6
   - 7.0
   - 7.1
   - 7.2
@@ -10,21 +12,30 @@ cache:
   directories:
     - $HOME/.composer/cache/files
 
+env:
+  - SYMFONY_VERSION=2.7.*
+
 matrix:
-  fast_finish: true
   include:
-    - php: 7.0
-      env: DEPENDENCIES="symfony/lts:^3";COMPOSER_FLAGS="--prefer-lowest"
+    - php: 5.6
+      env: SYMFONY_VERSION=2.8.*
+    - php: 5.6
+      env: SYMFONY_VERSION=3.3.*
+    - php: 5.6
+      env: SYMFONY_VERSION=3.4.*
+    - php: 7.1
+      env: SYMFONY_VERSION=4.0.*
     - php: 7.2
-      env: DEPENDENCIES="symfony/lts:^3"
+      env: SYMFONY_VERSION=4.0.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.7.*;COMPOSER_FLAGS="--prefer-lowest"
 
 before_install:
-  - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
-  - if [ "$DEPENDENCIES" != "" ]; then composer require --no-update $DEPENDENCIES; fi;
-  - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --quiet; fi
+  - if [[ $TRAVIS_PHP_VERSION != '7.0' && $TRAVIS_PHP_VERSION != '7.1' && $TRAVIS_PHP_VERSION != '7.2' ]]; then phpenv config-rm xdebug.ini; fi
+  - echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi
 
-install: travis_wait composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
+install: composer update --prefer-source $COMPOSER_FLAGS
 
 script: vendor/bin/phpunit --coverage-text
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: php
-sudo: required
-dist: trusty
-group: edge
+sudo: false
+
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
@@ -12,30 +10,21 @@ cache:
   directories:
     - $HOME/.composer/cache/files
 
-env:
-  - SYMFONY_VERSION=2.7.*
-
 matrix:
+  fast_finish: true
   include:
-    - php: 5.6
-      env: SYMFONY_VERSION=2.8.*
-    - php: 5.6
-      env: SYMFONY_VERSION=3.3.*
-    - php: 5.6
-      env: SYMFONY_VERSION=3.4.*
-    - php: 7.1
-      env: SYMFONY_VERSION=4.0.*
+    - php: 7.0
+      env: DEPENDENCIES="symfony/lts:^3";COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.2
-      env: SYMFONY_VERSION=4.0.*
-    - php: 5.6
-      env: SYMFONY_VERSION=2.7.*;COMPOSER_FLAGS="--prefer-lowest"
+      env: DEPENDENCIES="symfony/lts:^3"
 
 before_install:
-  - if [[ $TRAVIS_PHP_VERSION != '7.0' && $TRAVIS_PHP_VERSION != '7.1' && $TRAVIS_PHP_VERSION != '7.2' ]]; then phpenv config-rm xdebug.ini; fi
-  - echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi
+  - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
+  - if [ "$DEPENDENCIES" != "" ]; then composer require --no-update $DEPENDENCIES; fi;
+  - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --quiet; fi
 
-install: composer update --prefer-source $COMPOSER_FLAGS
+install: travis_wait composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 
 script: vendor/bin/phpunit --coverage-text
 

--- a/composer.json
+++ b/composer.json
@@ -26,23 +26,23 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.0",
-        "symfony/framework-bundle": "~3.0|^4.0",
+        "symfony/framework-bundle": "~3.1|^4.0",
         "zendframework/zenddiagnostics": "^1.2.0"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^1.0|^2.0",
         "sensiolabs/security-checker": "~1.3|~2.0|~3.0|~4.0",
         "guzzlehttp/guzzle": "^5.3.2|^6.3.3",
-        "symfony/expression-language": "~3.0|^4.0",
+        "symfony/expression-language": "~3.1|^4.0",
         "swiftmailer/swiftmailer": "~5.4",
         "doctrine/migrations": "~1.0",
         "doctrine/doctrine-migrations-bundle": "~1.0",
-        "symfony/twig-bundle": "^3.0|^4.0",
-        "symfony/browser-kit": "^3.0|^4.0",
-        "symfony/asset": "^3.0|^4.0",
-        "symfony/templating": "^3.0|^4.0",
+        "symfony/twig-bundle": "^3.1|^4.0",
+        "symfony/browser-kit": "^3.1|^4.0",
+        "symfony/asset": "^3.1|^4.0",
+        "symfony/templating": "^3.1|^4.0",
         "phpunit/phpunit": "^6.0",
-        "symfony/finder": "^3.0|^4.0"
+        "symfony/finder": "^3.1|^4.0"
     },
     "suggest": {
         "sensio/distribution-bundle": "To be able to use the composer ScriptHandler",

--- a/composer.json
+++ b/composer.json
@@ -25,24 +25,24 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^5.4|^7.0",
-        "symfony/framework-bundle": "~2.7|~3.0|^4.0",
+        "php": "^7.0",
+        "symfony/framework-bundle": "~3.0|^4.0",
         "zendframework/zenddiagnostics": "^1.2.0"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^1.0|^2.0",
         "sensiolabs/security-checker": "~1.3|~2.0|~3.0|~4.0",
-        "guzzlehttp/guzzle": "~3.8|~4.0|~5.0|~6.0",
-        "symfony/expression-language": "~2.3|~3.0|^4.0",
+        "guzzlehttp/guzzle": "^5.3.2|^6.3.3",
+        "symfony/expression-language": "~3.0|^4.0",
         "swiftmailer/swiftmailer": "~5.4",
         "doctrine/migrations": "~1.0",
         "doctrine/doctrine-migrations-bundle": "~1.0",
-        "symfony/twig-bundle": "^2.0|^3.0|^4.0",
-        "symfony/browser-kit": "^2.0|^3.0|^4.0",
-        "symfony/asset": "^2.0|^3.0|^4.0",
-        "symfony/templating": "^2.0|^3.0|^4.0",
-        "phpunit/phpunit": "^4.8.35|^6.0",
-        "symfony/finder": "^2.0|^3.0|^4.0"
+        "symfony/twig-bundle": "^3.0|^4.0",
+        "symfony/browser-kit": "^3.0|^4.0",
+        "symfony/asset": "^3.0|^4.0",
+        "symfony/templating": "^3.0|^4.0",
+        "phpunit/phpunit": "^6.0",
+        "symfony/finder": "^3.0|^4.0"
     },
     "suggest": {
         "sensio/distribution-bundle": "To be able to use the composer ScriptHandler",


### PR DESCRIPTION
Looks like the prefer-lowest problem was caused by https://github.com/composer/composer/issues/5355

This config has been adapted from the FOSUserBundle.