### PR TITLE
Fixed issues with SF4

### DIFF
--- a/DoctrineMigrations/Configuration.php
+++ b/DoctrineMigrations/Configuration.php
@@ -12,6 +12,13 @@ use Doctrine\Bundle\MigrationsBundle\Command\DoctrineCommand;
 class Configuration extends BaseConfiguration
 {
     /**
+     * Flag whether doctrine migrations bundle is installed
+     *
+     * @var bool
+     */
+    private static $haveMigrationBundle;
+
+    /**
      * Service container
      *
      * @var ContainerInterface
@@ -37,6 +44,14 @@ class Configuration extends BaseConfiguration
      */
     public function configure()
     {
+        if (self::$haveMigrationBundle === null) {
+            self::$haveMigrationBundle = class_exists(DoctrineCommand::class);
+        }
+
+        if (!self::$haveMigrationBundle) {
+            return;
+        }
+
         DoctrineCommand::configureMigrations($this->container, $this);
     }
 }

--- a/README.md
+++ b/README.md
@@ -316,6 +316,23 @@ liip_monitor:
                 # Connection name or an array of connection names
                 doctrine_dbal:        null # Example: [default, crm]
                 
+                # Checks to see if migrations from specified configuration file are applied
+                doctrine_migrations:
+                    # Examples:
+                    application_migrations: 
+                        configuration_file:  %kernel.root_dir%/Resources/config/migrations.yml
+                        connection:          default
+                    migrations_with_doctrine_bundle: 
+                        connection:          default
+                    migrations_with_doctrine_bundle_v2: default
+                    
+                    # Prototype
+                    name:
+                        # Absolute path to doctrine migrations configuration
+                        configuration_file:   ~
+                        # Connection name from doctrine DBAL configuration
+                        connection:           ~ # Required
+                
                 # Connection name or an array of connection names
                 doctrine_mongodb:        null # Example: [default, crm]
 

--- a/Resources/config/checks/doctrine_migrations.xml
+++ b/Resources/config/checks/doctrine_migrations.xml
@@ -15,6 +15,7 @@
 
         <service id="liip_monitor.check.doctrine_migrations.abstract_configuration"
                  class="Liip\MonitorBundle\DoctrineMigrations\Configuration"
+                 public="true"
                  abstract="true">
             <argument /> <!-- Connection -->
 


### PR DESCRIPTION
This PR fixes private service error with symfony 4 (#189 ) and simplifies health-check configuration when used with DoctrineMigrationsBundle bundle:

```yaml
liip_monitor:
  checks:
    doctrine_migrations:
      my_app: 'my_db_connection'
```

