### PR TITLE
Bugfix - If the project does not have Doctrine

### DIFF
--- a/DependencyInjection/LiipMonitorExtension.php
+++ b/DependencyInjection/LiipMonitorExtension.php
@@ -33,6 +33,13 @@ class LiipMonitorExtension extends Extension implements CompilerPassInterface
      * @var Connection
      */
     private $fakeConnection;
+    
+    public function __construct()
+    {
+        if (class_exists(Connection::class)) {
+            $this->fakeConnection = new Connection([], new Driver());
+        }
+    }
 
     /**
      * Loads the services based on your application configuration.
@@ -42,7 +49,6 @@ class LiipMonitorExtension extends Extension implements CompilerPassInterface
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $this->fakeConnection = new Connection([], new Driver());
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('runner.xml');
         $loader->load('helper.xml');


### PR DESCRIPTION
Since last release (2.7.1) with commit https://github.com/liip/LiipMonitorBundle/commit/c6efe9ab43614a8c016cfe037421b7f326ef84ae

A fakeConnection is created into `load` in `LiipMonitorExtension` with `Connection` Doctrine class
But if you have not doctrine, that's crash : see #191 

I have clean code to move this new affect into `__construct`