### PR TITLE
Deprecation symfony 4.2 fix

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,8 +22,14 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('liip_monitor', 'array');
+        $treeBuilder = new TreeBuilder('liip_monitor');
+        
+        // Keep compatibility with symfony/config < 4.2
+        if (\method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('liip_monitor');
+        }
 
         $rootNode
             ->beforeNormalization()


### PR DESCRIPTION
Hi,

this is one way to fix the deprecations.
Another way is to drop symfony <4.2 support.