### PR TITLE
Incompatibility with latest Swiftmailer 6.0

### DIFF
--- a/Helper/SwiftMailerReporter.php
+++ b/Helper/SwiftMailerReporter.php
@@ -104,7 +104,7 @@ class SwiftMailerReporter implements ReporterInterface
             }
         }
 
-        $message = Swift_Message::newInstance()
+        $message = (new Swift_Message())
             ->setSubject($this->subject)
             ->setFrom($this->sender)
             ->setTo($this->recipient)

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "sensiolabs/security-checker": "~1.3|~2.0|~3.0|~4.0|~5.0",
         "guzzlehttp/guzzle": "^5.3.2|^6.3.3",
         "symfony/expression-language": "~3.1|^4.0",
-        "swiftmailer/swiftmailer": "~5.4",
+        "swiftmailer/swiftmailer": "~5.4|~6.1",
         "doctrine/migrations": "~1.0",
         "doctrine/doctrine-migrations-bundle": "~1.0",
         "symfony/twig-bundle": "^3.1|^4.0",


### PR DESCRIPTION
After upgrading SwiftMailer to version 6, the old way for creating messages `Swift_Message::newInstance` was removed.