### PR TITLE
Add reporters endpoint

### DIFF
--- a/Controller/HealthCheckController.php
+++ b/Controller/HealthCheckController.php
@@ -217,4 +217,15 @@ class HealthCheckController
     {
         return $request->query->get('group') ?: $this->runnerManager->getDefaultGroup();
     }
+
+    /**
+     * @param string  $checkId
+     * @param Request $request
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function listReportersAction(Request $request)
+    {
+        return new JsonResponse($this->runnerManager->getReporters());
+    }
 }

--- a/Controller/HealthCheckController.php
+++ b/Controller/HealthCheckController.php
@@ -31,7 +31,7 @@ class HealthCheckController
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function indexAction(Request $request)
     {
@@ -63,7 +63,7 @@ class HealthCheckController
     }
 
     /**
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function listAction(Request $request)
     {
@@ -107,7 +107,7 @@ class HealthCheckController
     /**
      * @param Request $request
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function runAllChecksAction(Request $request)
     {
@@ -122,7 +122,7 @@ class HealthCheckController
     /**
      * @param Request $request
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function runAllChecksHttpStatusAction(Request $request)
     {
@@ -138,7 +138,7 @@ class HealthCheckController
      * @param string  $checkId
      * @param Request $request
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function runSingleCheckHttpStatusAction($checkId, Request $request)
     {
@@ -154,7 +154,7 @@ class HealthCheckController
      * @param string  $checkId
      * @param Request $request
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function runSingleCheckAction($checkId, Request $request)
     {
@@ -219,12 +219,9 @@ class HealthCheckController
     }
 
     /**
-     * @param string  $checkId
-     * @param Request $request
-     *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
-    public function listReportersAction(Request $request)
+    public function listReportersAction()
     {
         return new JsonResponse($this->runnerManager->getReporters());
     }

--- a/Controller/HealthCheckController.php
+++ b/Controller/HealthCheckController.php
@@ -29,7 +29,7 @@ class HealthCheckController
     }
 
     /**
-     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param Request $request
      *
      * @return Response
      */

--- a/Helper/RunnerManager.php
+++ b/Helper/RunnerManager.php
@@ -89,4 +89,19 @@ class RunnerManager
 
         return $this->container->has($runnerServiceId) ? $runnerServiceId : null;
     }
+
+    /**
+     * @return array
+     */
+    public function getReporters()
+    {
+        $runners = $this->getRunners();
+        $reporters = [];
+
+        foreach ($runners as $runner) {
+            $reporters += array_keys($runner->getReporters() + $runner->getAdditionalReporters());
+        }
+
+        return $reporters;
+    }
 }

--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -27,4 +27,7 @@
     <route id="liip_monitor_run_single_check" path="/run/{checkId}">
         <default key="_controller">Liip\MonitorBundle\Controller\HealthCheckController::runSingleCheckAction</default>
     </route>
+    <route id="liip_monitor_list_reporters" path="/list/reporters">
+        <default key="_controller">Liip\MonitorBundle\Controller\HealthCheckController::listReportersAction</default>
+    </route>
 </routes>

--- a/Resources/views/health/index.html.php
+++ b/Resources/views/health/index.html.php
@@ -112,6 +112,19 @@ $ curl -XPOST -H "Accept: application/json" <?php echo $request->getUriForPath($
 ]</pre>
         </dd>
 
+        <dt><a href="<?php echo $request->getUriForPath($request->getPathInfo().'list/reporters') ?>"><?php echo $request->getPathInfo().'list/reporters' ?></a></dt>
+        <dd>
+            Returns a list of additional reporters available as a JSON array.
+            <pre>
+$ curl -XGET -H "Accept: application/json" <?php echo $request->getUriForPath($request->getPathInfo().'list/reporters') ?>
+
+[
+    "newrelic_reporter",
+    "file_reporter",
+    "another_awesome_reporter"
+]</pre>
+        </dd>
+
         <dt><a href="<?php echo $request->getUriForPath($request->getPathInfo().'http_status_checks') ?>"><?php echo $request->getPathInfo().'http_status_checks' ?></a></dt>
         <dd>Performs all health checks and returns the results within the HTTP Status Code (200 if checks are OK, 502 otherwise).
 <pre>
@@ -148,13 +161,14 @@ $ curl -XPOST -H "Accept: application/json" <?php echo $request->getUriForPath($
 $ curl -XPOST -H "Accept: application/json" <?php echo $request->getUriForPath($request->getPathInfo().'run') ?>
 
 {
-"checks":
-    [
-        {"checkName": "Jackrabbit Health Check", "message": "OK", "status":true, "service_id": "monitor.check.jackrabbit"},
-        {"checkName": "Redis Health Check", "message": "OK", "status":true, "service_id": "monitor.check.redis"},
-        {"checkName": "Memcache Health Check", "message": "KO - No configuration set for session.save_path", "status":false, "service_id": "monitor.check.memcache"},
-        {"checkName": "PHP Extensions Health Check", "message": "OK", "status":true, "service_id": "monitor.check.php_extensions"}
-    ]
+    "checks":
+        [
+            {"checkName": "Jackrabbit Health Check", "message": "OK", "status":true, "service_id": "monitor.check.jackrabbit"},
+            {"checkName": "Redis Health Check", "message": "OK", "status":true, "service_id": "monitor.check.redis"},
+            {"checkName": "Memcache Health Check", "message": "KO - No configuration set for session.save_path", "status":false, "service_id": "monitor.check.memcache"},
+            {"checkName": "PHP Extensions Health Check", "message": "OK", "status":true, "service_id": "monitor.check.php_extensions"}
+        ],
+    "globalStatus": "OK|KO"
 }</pre>
         </dd>
 


### PR DESCRIPTION
This endpoint it's helpful in our case because we have different team working in that "integration and monitoring", to see the documentation in this way is better and easy to maintain, because in every implementation we need to implement the same endpoint only to display this default route. 

Also fixed the documentation where was missing the property "globalStatus".