### PR TITLE
Let RedisCollection handle valid redis DSNs with auth.

### DIFF
--- a/Check/RedisCollection.php
+++ b/Check/RedisCollection.php
@@ -10,24 +10,38 @@ use ZendDiagnostics\Check\Redis;
  */
 class RedisCollection implements CheckCollectionInterface
 {
-    private $checks = array();
+    private $checks = [];
 
     public function __construct(array $configs)
     {
         foreach ($configs as $name => $config) {
             if (isset($config['dsn'])) {
-                $config = array_merge($config, parse_url($config['dsn']));
-                if (isset($config['pass'])) {
-                    $config['password'] = $config['pass'];
-                    // Cleanup
-                    unset($config['pass']);
-                }
+                $this->parseDsn($config);
             }
 
             $check = new Redis($config['host'], $config['port'], $config['password']);
-            $check->setLabel(sprintf('Redis "%s"', $name));
+            $check->setLabel(\sprintf('Redis "%s"', $name));
 
-            $this->checks[sprintf('redis_%s', $name)] = $check;
+            $this->checks[\sprintf('redis_%s', $name)] = $check;
+        }
+    }
+
+    private function parseDsn(array &$config)
+    {
+        $config = \array_merge($config, \parse_url($config['dsn']));
+
+        if (isset($config['pass'])) {
+            $config['password'] = $config['pass'];
+            // Cleanup
+            unset($config['pass']);
+        } elseif (isset($config['user'])) {
+            /*
+             * since "redis://my-super-secret-password@redis-host:6379" is a valid redis
+             * dsn but \parse_url does not understand this notation and extracts the auth as user,
+             * we need to check for it.
+             */
+            $config['password'] = $config['user'];
+            unset($config['user']);
         }
     }
 

--- a/Tests/Check/RedisCollectionTest.php
+++ b/Tests/Check/RedisCollectionTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Liip\MonitorBundle\Tests\Check;
+
+use Liip\MonitorBundle\Check\RedisCollection;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionException;
+use ZendDiagnostics\Check\Redis;
+
+final class RedisCollectionTest extends TestCase
+{
+    const AUTH = 'my-super-secret-password';
+
+    /**
+     * @test
+     * @dataProvider provideDsnWithAut
+     */
+    public function handleDsnWithAuth(string $dsn)
+    {
+        $config = [
+          'dsn'      => $dsn,
+          'host'     => 'localhost',
+          'port'     => 6379,
+          'password' => null,
+        ];
+
+        $collection = new RedisCollection(['default' => $config]);
+        $checks     = $collection->getChecks();
+
+        /** @var \ZendDiagnostics\Check\Redis $check */
+        $check = $checks['redis_default'];
+
+        $this->assertAuthPropertyValue($check, self::AUTH);
+    }
+
+    /**
+     * @param \ZendDiagnostics\Check\Redis $check
+     * @param string                       $auth
+     */
+    private function assertAuthPropertyValue(Redis $check, string $auth)
+    {
+        try {
+            $refClass = new ReflectionClass($check);
+            $authProp = $refClass->getProperty('auth');
+            $authProp->setAccessible(true);
+            self::assertSame($auth, $authProp->getValue($check));
+
+        } catch (ReflectionException $e) {
+            self::fail($e->getMessage());
+        }
+    }
+
+    public function provideDsnWithAut(): array
+    {
+        return [
+          'incompatible with parse_url' => [sprintf('redis://%s@127.0.0.1:6379', static::AUTH)],
+          'compatible with parse_url'   => [sprintf('redis://irrelevant-user:%s@127.0.0.1:6379', static::AUTH)],
+        ];
+    }
+}


### PR DESCRIPTION
I have a redis connection with auth in my current project and so I found out that this bundle couldn't handle valid Redis DSNs like `redis://my-super-secret-password@redis-host:6379`.
