### PR TITLE
[BREAKING] Drop Support for PHP 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: required
 dist: trusty
 group: edge
 php:
-  - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 cache:
   directories:
@@ -22,8 +22,8 @@ matrix:
       env: SYMFONY_VERSION=4.1.*
     - php: 7.3
       env: SYMFONY_VERSION=4.2.*
-    - php: 7.0
-      env: SYMFONY_VERSION=3.1.*;COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.1
+      env: COMPOSER_FLAGS="--prefer-lowest"
 
 before_install:
   - echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
     - $HOME/.composer/cache/files
 
 env:
-  - SYMFONY_VERSION=3.1.*
+  - SYMFONY_VERSION=3.4.*
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi
 
-install: composer update --prefer-source $COMPOSER_FLAGS
+install: travis_wait composer update --prefer-source $COMPOSER_FLAGS
 
 script: vendor/bin/phpunit --coverage-text
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "zendframework/zenddiagnostics": "^1.2.0"
     },
     "require-dev": {
-        "matthiasnoback/symfony-dependency-injection-test": "^1.0|^2.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^3.0",
         "sensiolabs/security-checker": "~1.3|~2.0|~3.0|~4.0|~5.0",
         "guzzlehttp/guzzle": "^5.3.2|^6.3.3",
         "symfony/expression-language": "~3.1|^4.0",
@@ -41,7 +41,7 @@
         "symfony/browser-kit": "^3.1|^4.0",
         "symfony/asset": "^3.1|^4.0",
         "symfony/templating": "^3.1|^4.0",
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^7.0",
         "symfony/finder": "^3.1|^4.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -26,23 +26,23 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.1",
-        "symfony/framework-bundle": "~3.1|^4.0",
+        "symfony/framework-bundle": "~3.4|^4.0",
         "zendframework/zenddiagnostics": "^1.2.0"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^3.0",
         "sensiolabs/security-checker": "~1.3|~2.0|~3.0|~4.0|~5.0",
         "guzzlehttp/guzzle": "^5.3.2|^6.3.3",
-        "symfony/expression-language": "~3.1|^4.0",
+        "symfony/expression-language": "~3.4|^4.0",
         "swiftmailer/swiftmailer": "~5.4|~6.1",
         "doctrine/migrations": "~1.0",
         "doctrine/doctrine-migrations-bundle": "~1.0",
-        "symfony/twig-bundle": "^3.1|^4.0",
-        "symfony/browser-kit": "^3.1|^4.0",
-        "symfony/asset": "^3.1|^4.0",
-        "symfony/templating": "^3.1|^4.0",
+        "symfony/twig-bundle": "^3.4|^4.0",
+        "symfony/browser-kit": "^3.4|^4.0",
+        "symfony/asset": "^3.4|^4.0",
+        "symfony/templating": "^3.4|^4.0",
         "phpunit/phpunit": "^7.0",
-        "symfony/finder": "^3.1|^4.0"
+        "symfony/finder": "^3.4|^4.0"
     },
     "suggest": {
         "sensio/distribution-bundle": "To be able to use the composer ScriptHandler",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": "^7.1",
         "symfony/framework-bundle": "~3.4|^4.0",
-        "zendframework/zenddiagnostics": "^1.2.0"
+        "zendframework/zenddiagnostics": "^1.3.1"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "symfony/framework-bundle": "~3.1|^4.0",
         "zendframework/zenddiagnostics": "^1.2.0"
     },


### PR DESCRIPTION
Attempting to unlock #203 which requires a new minimum PHP version.

PHP 7.0 is end of life as of January, 7.1 is now the minimum safe version.

I left this in multiple commits so each step was clear and everything wasn't smashed together, let me know if you'd rather I squashed it. It ended up being a bit complicated as version bumps had a cascading effect. 