### PR TITLE
Possible fix for doctrine/migrations 2.0

### DIFF
--- a/DependencyInjection/LiipMonitorExtension.php
+++ b/DependencyInjection/LiipMonitorExtension.php
@@ -33,7 +33,7 @@ class LiipMonitorExtension extends Extension implements CompilerPassInterface
      * @var Connection
      */
     private $fakeConnection;
-    
+
     public function __construct()
     {
         if (class_exists(Connection::class)) {
@@ -268,8 +268,15 @@ class LiipMonitorExtension extends Extension implements CompilerPassInterface
         $result = array();
 
         $diff = new LiipMigrationConfiguration($connection);
-        $diff->setMigrationsNamespace($config->getMigrationsNamespace());
-        $diff->setMigrationsDirectory($config->getMigrationsDirectory());
+
+        if ($namespace = $config->getMigrationsNamespace()) {
+            $diff->setMigrationsNamespace($config->getMigrationsNamespace());
+        }
+
+        if ($dir = $config->getMigrationsDirectory()) {
+            $diff->setMigrationsDirectory($dir);
+        }
+
         $diff->setContainer($container);
         $diff->configure();
 


### PR DESCRIPTION
I was testing #203 and found it still worked as expected with doctrine/migrations 1.1 but was getting an error when using doctrine/migrations 2.0.

The problem was `$config->getMigrationsNamespace()`/ `$config->getMigrationsDirectory()` are returning `null` and `$diff->setMigrationsNamespace()`/`$diff->setMigrationsDirectory()` can no longer accept null.

This PR fixed the issue for me but I'm not sure if there are other ramifications... I don't have a deep understanding on how the migration check works.

ping @stopfstedt, @jrjohnson