### PR TITLE
Make the HTTP failure status code configurable.

### DIFF
--- a/Controller/HealthCheckController.php
+++ b/Controller/HealthCheckController.php
@@ -15,17 +15,20 @@ class HealthCheckController
     protected $runnerManager;
     protected $pathHelper;
     protected $template;
+    protected $failureStatusCode;
 
     /**
      * @param RunnerManager $runnerManager
      * @param PathHelper    $pathHelper
      * @param               $template
+     * @param               $failureStatusCode
      */
-    public function __construct(RunnerManager $runnerManager, PathHelper $pathHelper, $template)
+    public function __construct(RunnerManager $runnerManager, PathHelper $pathHelper, $template, $failureStatusCode)
     {
         $this->runnerManager = $runnerManager;
         $this->pathHelper = $pathHelper;
         $this->template = $template;
+        $this->failureStatusCode = $failureStatusCode;
     }
 
     /**
@@ -130,7 +133,7 @@ class HealthCheckController
 
         return new Response(
             '',
-            ($report->getGlobalStatus() === ArrayReporter::STATUS_OK ? 200 : 502)
+            ($report->getGlobalStatus() === ArrayReporter::STATUS_OK ? 200 : $this->failureStatusCode)
         );
     }
 
@@ -146,7 +149,7 @@ class HealthCheckController
 
         return new Response(
             '',
-            ($report->getGlobalStatus() === ArrayReporter::STATUS_OK ? 200 : 502)
+            ($report->getGlobalStatus() === ArrayReporter::STATUS_OK ? 200 : $this->failureStatusCode)
         );
     }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('liip_monitor');
-        
+
         // Keep compatibility with symfony/config < 4.2
         if (\method_exists($treeBuilder, 'getRootNode')) {
             $rootNode = $treeBuilder->getRootNode();
@@ -51,6 +51,10 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->booleanNode('enable_controller')->defaultFalse()->end()
                 ->scalarNode('view_template')->defaultNull()->end()
+                ->integerNode('failure_status_code')
+                    ->min(100)->max(598)
+                    ->defaultValue(502)
+                ->end()
                 ->arrayNode('mailer')
                     ->canBeEnabled()
                     ->children()

--- a/DependencyInjection/LiipMonitorExtension.php
+++ b/DependencyInjection/LiipMonitorExtension.php
@@ -63,6 +63,7 @@ class LiipMonitorExtension extends Extension implements CompilerPassInterface
 
         if ($config['enable_controller']) {
             $container->setParameter(sprintf('%s.view_template', $this->getAlias()), $config['view_template']);
+            $container->setParameter(sprintf('%s.failure_status_code', $this->getAlias()), $config['failure_status_code']);
             $loader->load('controller.xml');
         }
 

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ groups. Additionally, the `monitor:list` has an option `--groups` to list all re
 liip_monitor:
     enable_controller:    false
     view_template:        null
+    failure_status_code:  502
     mailer:
         enabled:              false
         recipient:            ~ # Required

--- a/Resources/config/controller.xml
+++ b/Resources/config/controller.xml
@@ -16,6 +16,7 @@
             <argument type="service" id="liip_monitor.helper.runner_manager" />
             <argument type="service" id="liip_monitor.helper" />
             <argument>%liip_monitor.view_template%</argument>
+            <argument>%liip_monitor.failure_status_code%</argument>
         </service>
     </services>
 </container>

--- a/Resources/views/health/index.html.php
+++ b/Resources/views/health/index.html.php
@@ -126,7 +126,7 @@ $ curl -XGET -H "Accept: application/json" <?php echo $request->getUriForPath($r
         </dd>
 
         <dt><a href="<?php echo $request->getUriForPath($request->getPathInfo().'http_status_checks') ?>"><?php echo $request->getPathInfo().'http_status_checks' ?></a></dt>
-        <dd>Performs all health checks and returns the results within the HTTP Status Code (200 if checks are OK, 502 otherwise).
+        <dd>Performs all health checks and returns the results within the HTTP Status Code (200 if checks are OK, 502 otherwise). The failure status code is configurable as <code>failure_status_code</code>.
 <pre>
 $ curl -XPOST -H "Accept: application/json" <?php echo $request->getUriForPath($request->getPathInfo().'http_status_checks') ?>
 
@@ -141,7 +141,7 @@ HTTP/1.1 502 Bad Gateway
         </dd>
 
         <dt><?php echo $request->getPathInfo().'http_status_check/check_id' ?></dt>
-        <dd>Performs the health check specified by <code>check_id</code> and returns the result within the HTTP Status Code (200 if checks are OK, 502 otherwise).
+        <dd>Performs the health check specified by <code>check_id</code> and returns the result within the HTTP Status Code (200 if checks are OK, 502 otherwise). The failure status code is configurable as <code>failure_status_code</code>.
 <pre>
 $ curl -XPOST -H "Accept: application/json" <?php echo $request->getUriForPath($request->getPathInfo().'http_status_check/monitor.check.redis') ?>
 


### PR DESCRIPTION
This PR is an implementation of #213.  As discussed, the value is set to have the default be the existing 502 value.

Questions of mine: looks like there's no existing test for the controller... should there be?