### PR TITLE
cannotBeEmpty on arrayNode is deprecated in symfony 3 and removed in 4

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -59,7 +59,7 @@ class Configuration implements ConfigurationInterface
                     ->canBeEnabled()
                     ->children()
                         ->arrayNode('recipient')
-                            ->isRequired()->cannotBeEmpty()
+                            ->isRequired()->requiresAtLeastOneElement()
                             ->prototype('scalar')->end()
                             ->beforeNormalization()
                                 ->ifString()


### PR DESCRIPTION
Here is the warning when using symfony 3.4 :

    Using Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition::cannotBeEmpty() at path "liip_monitor.mailer.recipient" has no effect, consider requiresAtLeastOneElement() instead. In 4.0 both methods will behave the same.

See symfony source code, it's a `@trigger_error` in sf3 and an exception in sf4 : 

- 3.4 : https://github.com/symfony/config/blob/3.4/Definition/Builder/ArrayNodeDefinition.php#L415
- 4.0 : https://github.com/symfony/config/blob/4.0/Definition/Builder/ArrayNodeDefinition.php#L476

A similar fix can be viewed in another bundle : https://github.com/nelmio/NelmioJsLoggerBundle/pull/20