### PR TITLE
Fix ListChecksCommand for Symfony 5

### DIFF
--- a/Command/ListChecksCommand.php
+++ b/Command/ListChecksCommand.php
@@ -50,6 +50,8 @@ class ListChecksCommand extends Command
                 $this->listChecks($input, $output);
                 break;
         }
+
+        return 0;
     }
 
     protected function listChecks(InputInterface $input, OutputInterface $output)


### PR DESCRIPTION
Symfony 5 commands MUST return exit code in execute() method. If it doesn't return int, TypeError throws.

From [Symfony Console](https://symfony.com/doc/4.4/console.html) docs:

> Deprecated since version 4.4:Not returning an integer with the exit status as the result of execute() is deprecated since Symfony 4.4.