### PR TITLE
Fix mailer configuration extension

### DIFF
--- a/DependencyInjection/Compiler/MailerCompilerPass.php
+++ b/DependencyInjection/Compiler/MailerCompilerPass.php
@@ -6,7 +6,6 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\Mailer\MailerInterface;
 
 /**
  * Class MailerCompilerPass.
@@ -33,9 +32,9 @@ class MailerCompilerPass implements CompilerPassInterface
         }
 
         $definition = $container->getDefinition('mailer');
-        $filename   = \Swift_Mailer::class !== $definition->getClass() ? 'symfony_mailer.xml' : 'swift_mailer.xml';
+        $filename = \Swift_Mailer::class !== $definition->getClass() ? 'symfony_mailer.xml' : 'swift_mailer.xml';
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../../Resources/config'));
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../../Resources/config'));
         $loader->load($filename);
     }
 }

--- a/DependencyInjection/Compiler/MailerCompilerPass.php
+++ b/DependencyInjection/Compiler/MailerCompilerPass.php
@@ -16,7 +16,7 @@ use Symfony\Component\Mailer\MailerInterface;
 class MailerCompilerPass implements CompilerPassInterface
 {
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function process(ContainerBuilder $container)
     {

--- a/DependencyInjection/Compiler/MailerCompilerPass.php
+++ b/DependencyInjection/Compiler/MailerCompilerPass.php
@@ -8,8 +8,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
 
 /**
- * Class MailerCompilerPass.
- *
  * @author Carlos Dominguez <ixarlie@gmail.com>
  */
 class MailerCompilerPass implements CompilerPassInterface

--- a/DependencyInjection/Compiler/MailerCompilerPass.php
+++ b/DependencyInjection/Compiler/MailerCompilerPass.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Liip\MonitorBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\Mailer\MailerInterface;
+
+/**
+ * Class MailerCompilerPass.
+ *
+ * @author Carlos Dominguez <ixarlie@gmail.com>
+ */
+class MailerCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (false === $container->hasParameter('liip_monitor.mailer.enabled')) {
+            return;
+        }
+
+        if (false === $container->getParameter('liip_monitor.mailer.enabled')) {
+            return;
+        }
+
+        if (!$container->hasDefinition('mailer')) {
+            throw new \InvalidArgumentException('To enable mail reporting you have to install the "swiftmailer/swiftmailer" or "symfony/mailer".');
+        }
+
+        $definition = $container->getDefinition('mailer');
+        $filename   = \Swift_Mailer::class !== $definition->getClass() ? 'symfony_mailer.xml' : 'swift_mailer.xml';
+
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../../Resources/config'));
+        $loader->load($filename);
+    }
+}

--- a/DependencyInjection/LiipMonitorExtension.php
+++ b/DependencyInjection/LiipMonitorExtension.php
@@ -239,9 +239,7 @@ class LiipMonitorExtension extends Extension implements CompilerPassInterface
     private function configureMailer(ContainerBuilder $container, LoaderInterface $loader, array $config)
     {
         if (false === $config['mailer']['enabled']) {
-            $config['mailer'] = [
-                'enabled' => false,
-            ];
+            return;
         }
 
         foreach ($config['mailer'] as $key => $value) {

--- a/DependencyInjection/LiipMonitorExtension.php
+++ b/DependencyInjection/LiipMonitorExtension.php
@@ -15,7 +15,6 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
-use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -240,17 +239,10 @@ class LiipMonitorExtension extends Extension implements CompilerPassInterface
     private function configureMailer(ContainerBuilder $container, LoaderInterface $loader, array $config)
     {
         if (false === $config['mailer']['enabled']) {
-            return;
+            $config['mailer'] = [
+                'enabled' => false,
+            ];
         }
-
-        try {
-            $mailerDefinition = $container->findDefinition('mailer');
-        } catch (ServiceNotFoundException $e) {
-            throw new \InvalidArgumentException('To enable mail reporting you have to install the "swiftmailer/swiftmailer" or "symfony/mailer".');
-        }
-
-        $filename = \Swift_Mailer::class !== $mailerDefinition->getClass() ? 'symfony_mailer.xml' : 'swift_mailer.xml';
-        $loader->load($filename);
 
         foreach ($config['mailer'] as $key => $value) {
             $container->setParameter(sprintf('%s.mailer.%s', $this->getAlias(), $key), $value);

--- a/LiipMonitorBundle.php
+++ b/LiipMonitorBundle.php
@@ -8,6 +8,7 @@ use Liip\MonitorBundle\DependencyInjection\Compiler\CheckAssetsEnabledPass;
 use Liip\MonitorBundle\DependencyInjection\Compiler\CheckCollectionTagCompilerPass;
 use Liip\MonitorBundle\DependencyInjection\Compiler\CheckTagCompilerPass;
 use Liip\MonitorBundle\DependencyInjection\Compiler\GroupRunnersCompilerPass;
+use Liip\MonitorBundle\DependencyInjection\Compiler\MailerCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -26,5 +27,6 @@ class LiipMonitorBundle extends Bundle
         $container->addCompilerPass(new CheckTagCompilerPass());
         $container->addCompilerPass(new CheckCollectionTagCompilerPass());
         $container->addCompilerPass(new AdditionalReporterCompilerPass());
+        $container->addCompilerPass(new MailerCompilerPass());
     }
 }

--- a/Tests/DependencyInjection/Compiler/MailerCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MailerCompilerPassTest.php
@@ -117,7 +117,7 @@ class MailerCompilerPassTest extends AbstractCompilerPassTestCase
         $this->compile();
     }
 
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new MailerCompilerPass());
     }

--- a/Tests/DependencyInjection/Compiler/MailerCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MailerCompilerPassTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Liip\MonitorBundle\Tests\DependencyInjection\Compiler;
+
+use Liip\MonitorBundle\DependencyInjection\Compiler\MailerCompilerPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\Mailer\MailerInterface;
+
+class MailerCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    public function testProcessWithDisableMailer()
+    {
+        $this->setParameter('liip_monitor.mailer.enabled', false);
+
+        $this->compile();
+
+        $this->assertContainerBuilderNotHasService('liip_monitor.reporter.symfony_mailer');
+        $this->assertContainerBuilderNotHasService('liip_monitor.reporter.swift_mailer');
+    }
+
+    public function testProcessSwiftMailer()
+    {
+        $this->setParameter('liip_monitor.mailer.enabled', true);
+        $this->setDefinition('mailer', new Definition(\Swift_Mailer::class));
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasService('liip_monitor.reporter.swift_mailer');
+        $this->assertContainerBuilderNotHasService('liip_monitor.reporter.symfony_mailer');
+    }
+
+    public function testSymfonyMailer()
+    {
+        $this->setParameter('liip_monitor.mailer.enabled', true);
+        $this->setDefinition('mailer', new Definition(MailerInterface::class));
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasService('liip_monitor.reporter.symfony_mailer');
+        $this->assertContainerBuilderNotHasService('liip_monitor.reporter.swift_mailer');
+    }
+
+    public function testMailerWithoutPackage()
+    {
+        $this->setParameter('liip_monitor.mailer.enabled', true);
+        $this->expectExceptionMessage('To enable mail reporting you have to install the "swiftmailer/swiftmailer" or "symfony/mailer".');
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->compile();
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new MailerCompilerPass());
+    }
+}

--- a/Tests/DependencyInjection/Compiler/MailerCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MailerCompilerPassTest.php
@@ -3,14 +3,17 @@
 namespace Liip\MonitorBundle\Tests\DependencyInjection\Compiler;
 
 use Liip\MonitorBundle\DependencyInjection\Compiler\MailerCompilerPass;
+use Liip\MonitorBundle\Helper\SwiftMailerReporter;
+use Liip\MonitorBundle\Helper\SymfonyMailerReporter;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Mailer\MailerInterface;
 
 class MailerCompilerPassTest extends AbstractCompilerPassTestCase
 {
-    public function testProcessWithDisableMailer()
+    public function testDisabledMailer()
     {
         $this->setParameter('liip_monitor.mailer.enabled', false);
 
@@ -20,15 +23,46 @@ class MailerCompilerPassTest extends AbstractCompilerPassTestCase
         $this->assertContainerBuilderNotHasService('liip_monitor.reporter.swift_mailer');
     }
 
-    public function testProcessSwiftMailer()
+    public function testSwiftMailer()
     {
         $this->setParameter('liip_monitor.mailer.enabled', true);
         $this->setDefinition('mailer', new Definition(\Swift_Mailer::class));
 
         $this->compile();
 
-        $this->assertContainerBuilderHasService('liip_monitor.reporter.swift_mailer');
         $this->assertContainerBuilderNotHasService('liip_monitor.reporter.symfony_mailer');
+        $this->assertContainerBuilderHasService('liip_monitor.reporter.swift_mailer', SwiftMailerReporter::class);
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'liip_monitor.reporter.swift_mailer',
+            0,
+            new Reference('mailer')
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'liip_monitor.reporter.swift_mailer',
+            1,
+            '%liip_monitor.mailer.recipient%'
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'liip_monitor.reporter.swift_mailer',
+            2,
+            '%liip_monitor.mailer.sender%'
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'liip_monitor.reporter.swift_mailer',
+            3,
+            '%liip_monitor.mailer.subject%'
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'liip_monitor.reporter.swift_mailer',
+            4,
+            '%liip_monitor.mailer.send_on_warning%'
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            'liip_monitor.reporter.swift_mailer',
+            'liip_monitor.additional_reporter',
+            ['alias' => 'swift_mailer']
+        );
     }
 
     public function testSymfonyMailer()
@@ -38,8 +72,39 @@ class MailerCompilerPassTest extends AbstractCompilerPassTestCase
 
         $this->compile();
 
-        $this->assertContainerBuilderHasService('liip_monitor.reporter.symfony_mailer');
         $this->assertContainerBuilderNotHasService('liip_monitor.reporter.swift_mailer');
+        $this->assertContainerBuilderHasService('liip_monitor.reporter.symfony_mailer', SymfonyMailerReporter::class);
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'liip_monitor.reporter.symfony_mailer',
+            0,
+            new Reference('mailer')
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'liip_monitor.reporter.symfony_mailer',
+            1,
+            '%liip_monitor.mailer.recipient%'
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'liip_monitor.reporter.symfony_mailer',
+            2,
+            '%liip_monitor.mailer.sender%'
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'liip_monitor.reporter.symfony_mailer',
+            3,
+            '%liip_monitor.mailer.subject%'
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'liip_monitor.reporter.symfony_mailer',
+            4,
+            '%liip_monitor.mailer.send_on_warning%'
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            'liip_monitor.reporter.symfony_mailer',
+            'liip_monitor.additional_reporter',
+            ['alias' => 'symfony_mailer']
+        );
     }
 
     public function testMailerWithoutPackage()

--- a/Tests/DependencyInjection/Compiler/MailerCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MailerCompilerPassTest.php
@@ -113,6 +113,7 @@ class MailerCompilerPassTest extends AbstractCompilerPassTestCase
         $this->expectExceptionMessage('To enable mail reporting you have to install the "swiftmailer/swiftmailer" or "symfony/mailer".');
         $this->expectException(\InvalidArgumentException::class);
 
+        $this->assertContainerBuilderNotHasService('mailer');
         $this->compile();
     }
 

--- a/Tests/DependencyInjection/LiipMonitorExtensionTest.php
+++ b/Tests/DependencyInjection/LiipMonitorExtensionTest.php
@@ -100,7 +100,7 @@ class LiipMonitorExtensionTest extends AbstractExtensionTestCase
     {
         $this->load();
 
-        $this->assertContainerBuilderHasParameter('liip_monitor.mailer.enabled', false);
+        $this->assertFalse($this->container->hasParameter('liip_monitor.mailer.enabled'));
         $this->assertFalse($this->container->hasParameter('liip_monitor.mailer.recipient'));
         $this->assertFalse($this->container->hasParameter('liip_monitor.mailer.sender'));
         $this->assertFalse($this->container->hasParameter('liip_monitor.mailer.subject'));
@@ -121,7 +121,7 @@ class LiipMonitorExtensionTest extends AbstractExtensionTestCase
             ]
         );
 
-        $this->assertContainerBuilderHasParameter('liip_monitor.mailer.enabled', false);
+        $this->assertFalse($this->container->hasParameter('liip_monitor.mailer.enabled'));
         $this->assertFalse($this->container->hasParameter('liip_monitor.mailer.recipient'));
         $this->assertFalse($this->container->hasParameter('liip_monitor.mailer.sender'));
         $this->assertFalse($this->container->hasParameter('liip_monitor.mailer.subject'));

--- a/Tests/DependencyInjection/LiipMonitorExtensionTest.php
+++ b/Tests/DependencyInjection/LiipMonitorExtensionTest.php
@@ -9,7 +9,6 @@ use Liip\MonitorBundle\DependencyInjection\Compiler\GroupRunnersCompilerPass;
 use Liip\MonitorBundle\DependencyInjection\LiipMonitorExtension;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
-use Symfony\Component\Mailer\MailerInterface;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -113,7 +112,7 @@ class LiipMonitorExtensionTest extends AbstractExtensionTestCase
         $this->load(
             [
                 'mailer' => [
-                    'enabled'   => false,
+                    'enabled' => false,
                     'recipient' => 'foo@example.com',
                     'sender' => 'bar@example.com',
                     'subject' => 'Health Check',
@@ -134,7 +133,7 @@ class LiipMonitorExtensionTest extends AbstractExtensionTestCase
         $this->load(
             [
                 'mailer' => [
-                    'enabled'   => true,
+                    'enabled' => true,
                     'recipient' => 'foo@example.com',
                     'sender' => 'bar@example.com',
                     'subject' => 'Health Check',

--- a/Tests/DependencyInjection/LiipMonitorExtensionTest.php
+++ b/Tests/DependencyInjection/LiipMonitorExtensionTest.php
@@ -97,12 +97,19 @@ class LiipMonitorExtensionTest extends AbstractExtensionTestCase
         $this->assertTrue($this->container->has('liip_monitor.health_controller'));
     }
 
-    public function testDisabledMailer()
+    public function testDisabledDefaultMailer()
     {
         $this->load();
 
         $this->assertContainerBuilderHasParameter('liip_monitor.mailer.enabled', false);
+        $this->assertFalse($this->container->hasParameter('liip_monitor.mailer.recipient'));
+        $this->assertFalse($this->container->hasParameter('liip_monitor.mailer.sender'));
+        $this->assertFalse($this->container->hasParameter('liip_monitor.mailer.subject'));
+        $this->assertFalse($this->container->hasParameter('liip_monitor.mailer.send_on_warning'));
+    }
 
+    public function testDisabledMailer()
+    {
         $this->load(
             [
                 'mailer' => [
@@ -120,6 +127,27 @@ class LiipMonitorExtensionTest extends AbstractExtensionTestCase
         $this->assertFalse($this->container->hasParameter('liip_monitor.mailer.sender'));
         $this->assertFalse($this->container->hasParameter('liip_monitor.mailer.subject'));
         $this->assertFalse($this->container->hasParameter('liip_monitor.mailer.send_on_warning'));
+    }
+
+    public function testEnabledMailer()
+    {
+        $this->load(
+            [
+                'mailer' => [
+                    'enabled'   => true,
+                    'recipient' => 'foo@example.com',
+                    'sender' => 'bar@example.com',
+                    'subject' => 'Health Check',
+                    'send_on_warning' => true,
+                ],
+            ]
+        );
+
+        $this->assertContainerBuilderHasParameter('liip_monitor.mailer.enabled', true);
+        $this->assertContainerBuilderHasParameter('liip_monitor.mailer.recipient', ['foo@example.com']);
+        $this->assertContainerBuilderHasParameter('liip_monitor.mailer.sender', 'bar@example.com');
+        $this->assertContainerBuilderHasParameter('liip_monitor.mailer.subject', 'Health Check');
+        $this->assertContainerBuilderHasParameter('liip_monitor.mailer.send_on_warning', true);
     }
 
     /**

--- a/Tests/LiipMonitorBundleTest.php
+++ b/Tests/LiipMonitorBundleTest.php
@@ -32,6 +32,7 @@ class LiipMonitorBundleTest extends \PHPUnit\Framework\TestCase
             'Liip\MonitorBundle\DependencyInjection\Compiler\CheckTagCompilerPass' => true,
             'Liip\MonitorBundle\DependencyInjection\Compiler\CheckCollectionTagCompilerPass' => true,
             'Liip\MonitorBundle\DependencyInjection\Compiler\AdditionalReporterCompilerPass' => true,
+            'Liip\MonitorBundle\DependencyInjection\Compiler\MailerCompilerPass' => true,
         ];
 
         $this->container->expects($this->exactly(count($compilerPasses)))


### PR DESCRIPTION
The mailer configuration is not correctly loaded, in the extension, when it is enabled.

The exception is always raised even when swiftmailer/swiftmailer or symfony/mailer are installed.

The ExtensionInterface::load method can access the parameters only because Symfony pass a copy of the container which only has the parameters from the actual container.

Fixes https://github.com/liip/LiipMonitorBundle/pull/219#discussion_r366888239