### PR TITLE
Fix mailer compiler pass

### DIFF
--- a/DependencyInjection/Compiler/MailerCompilerPass.php
+++ b/DependencyInjection/Compiler/MailerCompilerPass.php
@@ -5,6 +5,7 @@ namespace Liip\MonitorBundle\DependencyInjection\Compiler;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\Loader;
 
 /**
@@ -22,11 +23,12 @@ class MailerCompilerPass implements CompilerPassInterface
             return;
         }
 
-        if (!$container->hasDefinition('mailer')) {
+        try {
+            $definition = $container->findDefinition('mailer');
+        } catch (ServiceNotFoundException $e) {
             throw new \InvalidArgumentException('To enable mail reporting you have to install the "swiftmailer/swiftmailer" or "symfony/mailer".');
         }
 
-        $definition = $container->getDefinition('mailer');
         $filename = \Swift_Mailer::class !== $definition->getClass() ? 'symfony_mailer.xml' : 'swift_mailer.xml';
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../../Resources/config'));

--- a/Tests/DependencyInjection/Compiler/MailerCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/MailerCompilerPassTest.php
@@ -65,6 +65,19 @@ class MailerCompilerPassTest extends AbstractCompilerPassTestCase
         );
     }
 
+    public function testSwiftMailerWithAliasDefinition()
+    {
+        $this->setParameter('liip_monitor.mailer.enabled', true);
+        $this->setDefinition('swift.mailer', new Definition(\Swift_Mailer::class));
+        $this->container->setAlias('mailer', 'swift.mailer');
+
+        $this->assertContainerBuilderHasAlias('mailer');
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasService('liip_monitor.reporter.swift_mailer', SwiftMailerReporter::class);
+    }
+
     public function testSymfonyMailer()
     {
         $this->setParameter('liip_monitor.mailer.enabled', true);
@@ -107,6 +120,19 @@ class MailerCompilerPassTest extends AbstractCompilerPassTestCase
         );
     }
 
+    public function testSymfonyMailerWithAliasDefinition()
+    {
+        $this->setParameter('liip_monitor.mailer.enabled', true);
+        $this->setDefinition('symfony.mailer', new Definition(MailerInterface::class));
+        $this->container->setAlias('mailer', 'symfony.mailer');
+
+        $this->assertContainerBuilderHasAlias('mailer');
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasService('liip_monitor.reporter.symfony_mailer', SymfonyMailerReporter::class);
+    }
+
     public function testMailerWithoutPackage()
     {
         $this->setParameter('liip_monitor.mailer.enabled', true);
@@ -114,6 +140,19 @@ class MailerCompilerPassTest extends AbstractCompilerPassTestCase
         $this->expectException(\InvalidArgumentException::class);
 
         $this->assertContainerBuilderNotHasService('mailer');
+        $this->compile();
+    }
+
+    public function testMailerMissingAliasDefinition()
+    {
+        $this->setParameter('liip_monitor.mailer.enabled', true);
+        $this->setDefinition('swift.mailer', new Definition(\Swift_Mailer::class));
+
+        $this->assertFalse($this->container->hasAlias('mailer'));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('To enable mail reporting you have to install the "swiftmailer/swiftmailer" or "symfony/mailer".');
+
         $this->compile();
     }
 


### PR DESCRIPTION
I am really sorry @kbond but I changed something that I should not.

The 'mailer' service is added as an alias but `hasDefinition` does not search in the alias definitions property. My bad.