### PR TITLE
Replace root_dir with project_dir for security check

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -332,7 +332,7 @@ class Configuration implements ConfigurationInterface
                     ->arrayNode('security_advisory')
                         ->info('Checks installed composer dependencies against the SensioLabs Security Advisory database')
                         ->children()
-                            ->scalarNode('lock_file')->defaultValue('%kernel.root_dir%'.'/../composer.lock')->end()
+                            ->scalarNode('lock_file')->defaultValue('%kernel.project_dir%/composer.lock')->end()
                         ->end()
                     ->end()
                     ->arrayNode('stream_wrapper_exists')


### PR DESCRIPTION
`kernel.root_dir` was [deprecated in symfony 4.2](https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-the-kernel-name-and-the-root-dir) and removed in Symfony 5.

Enabling the `security_advisory` check and running `monitor:health` in a fresh Symfony 5 app will result in 
```
The parameter "liip_monitor.check.security_advisory.lock_file.default" has a dependency on a non-existent parameter "kernel.root_dir". 

Did you mean one of these: "kernel.project_dir", "kernel.cache_dir" , "kernel.logs_dir"? 
```

There are several usages of this in [DependencyInjection/Configuration](https://github.com/liip/LiipMonitorBundle/blob/master/DependencyInjection/Configuration.php) but the rest seemed to apply only to older Symfony project layouts so I left them alone.
