### PR TITLE
Use current command's output for Console reporters

### DIFF
--- a/Command/HealthCheckCommand.php
+++ b/Command/HealthCheckCommand.php
@@ -72,6 +72,8 @@ class HealthCheckCommand extends Command
             $reporter = $this->reporter;
         }
 
+        $reporter->setOutput($output);
+
         if ($allGroups) {
             $groups = $this->runnerManager->getGroups();
         }

--- a/Helper/ConsoleReporter.php
+++ b/Helper/ConsoleReporter.php
@@ -33,6 +33,11 @@ class ConsoleReporter implements ReporterInterface
         $this->output = $output;
     }
 
+    public function setOutput(OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
     public function onAfterRun(CheckInterface $check, ResultInterface $result, $checkAlias = null)
     {
         switch (true) {

--- a/Helper/RawConsoleReporter.php
+++ b/Helper/RawConsoleReporter.php
@@ -33,6 +33,11 @@ class RawConsoleReporter implements ReporterInterface
         $this->output = $output;
     }
 
+    public function setOutput(OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
     public function onAfterRun(CheckInterface $check, ResultInterface $result, $checkAlias = null)
     {
         switch (true) {


### PR DESCRIPTION
I had an issue when trying to capture the command's output programatically. This is because the Console reporters use `ConsoleOutput` by default.

This PR has the command create the proper console reporter using it's current output. This enabled me to remove the dependencies. I kept the services for BC.

Does anyone think this would cause a BC break?