### PR TITLE
Allow custom_error_pages check to work in Symfony 4.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,9 +415,11 @@ liip_monitor:
 
                 # Checks if error pages have been customized for given error codes
                 custom_error_pages:
+                    # The status codes that should be customized
                     error_codes:          [] # Required
-                    path:                 '%kernel.root_dir%'
-                    controller:           '%twig.exception_listener.controller%'
+
+                    # The directory where your custom error page twig templates are located. Keep as "%kernel.project_dir%" to use default location.
+                    path:                 '%kernel.project_dir%'
 
                 # Checks installed composer dependencies against the SensioLabs Security Advisory database
                 security_advisory:

--- a/Resources/config/checks/custom_error_pages.xml
+++ b/Resources/config/checks/custom_error_pages.xml
@@ -8,7 +8,7 @@
         <service id="liip_monitor.check.custom_error_pages" public="true" class="Liip\MonitorBundle\Check\CustomErrorPages">
             <argument>%%liip_monitor.check.custom_error_pages.error_codes%%</argument>
             <argument>%%liip_monitor.check.custom_error_pages.path%%</argument>
-            <argument>%%liip_monitor.check.custom_error_pages.controller%%</argument>
+            <argument>%kernel.project_dir%</argument>
             <tag name="liip_monitor.check" alias="custom_error_pages" />
         </service>
     </services>

--- a/Tests/DependencyInjection/LiipMonitorExtensionTest.php
+++ b/Tests/DependencyInjection/LiipMonitorExtensionTest.php
@@ -69,6 +69,7 @@ class LiipMonitorExtensionTest extends AbstractExtensionTestCase
             $checkAlias = $name;
         }
 
+        $this->container->setParameter('kernel.project_dir', __DIR__);
         $this->load(['checks' => [$name => $config]]);
         $this->compile();
 
@@ -258,7 +259,7 @@ class LiipMonitorExtensionTest extends AbstractExtensionTestCase
             ['guzzle_http_service', ['foo' => null], GuzzleHttpService::class, 'guzzle_http_service_foo'],
             ['rabbit_mq', ['foo' => null], RabbitMQ::class, 'rabbit_mq_foo'],
             ['symfony_version', null, SymfonyVersion::class],
-            ['custom_error_pages', ['error_codes' => [500], 'path' => __DIR__, 'controller' => 'foo'], CustomErrorPages::class],
+            ['custom_error_pages', ['error_codes' => [500]], CustomErrorPages::class],
             ['security_advisory', ['lock_file' => __DIR__.'/../../composer.lock'], SecurityAdvisory::class],
             ['stream_wrapper_exists', ['foo'], StreamWrapperExists::class],
             ['file_ini', ['foo.ini'], IniFile::class],


### PR DESCRIPTION
- deprecated "controller" option as it's no longer required
- default "path" to "kernel.project_dir"
- in check, if using the default path, check for templates in the default directory
for the current version of symfony
- in check, if using non-default path, check for templates here

As described in #242, I believe this check has been broken since 4.0 (false positive in 4.x/5.0 and errors in 5.1).

I removed the code that checks the "exception controller" and just check the configured path for the required templates. If the given path is `kernel.project_dir`, look for the templates in `app/Resources/TwigBundle/views/Exception` if using 3.4 and `templates/bundles/TwigBundle/Exception` if using 4.0+.