### PR TITLE
Fixed incorrect namespace for doctrine connection manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /Tests/app/var
 /vendor
 composer.lock
+.phpunit.result.cache

--- a/Check/DoctrineDbal.php
+++ b/Check/DoctrineDbal.php
@@ -2,7 +2,7 @@
 
 namespace Liip\MonitorBundle\Check;
 
-use Doctrine\Common\Persistence\ConnectionRegistry;
+use Doctrine\Persistence\ConnectionRegistry;
 use Laminas\Diagnostics\Check\AbstractCheck;
 use Laminas\Diagnostics\Result\Success;
 

--- a/Check/DoctrineDbalCollection.php
+++ b/Check/DoctrineDbalCollection.php
@@ -2,7 +2,7 @@
 
 namespace Liip\MonitorBundle\Check;
 
-use Doctrine\Common\Persistence\ConnectionRegistry;
+use Doctrine\Persistence\ConnectionRegistry;
 use Laminas\Diagnostics\Check\CheckCollectionInterface;
 
 /**

--- a/Check/DoctrineMongoDbCollection.php
+++ b/Check/DoctrineMongoDbCollection.php
@@ -2,7 +2,7 @@
 
 namespace Liip\MonitorBundle\Check;
 
-use Doctrine\Common\Persistence\ConnectionRegistry;
+use Doctrine\Persistence\ConnectionRegistry;
 use Laminas\Diagnostics\Check\CheckCollectionInterface;
 
 /**

--- a/Tests/DependencyInjection/LiipMonitorExtensionTest.php
+++ b/Tests/DependencyInjection/LiipMonitorExtensionTest.php
@@ -47,7 +47,7 @@ class LiipMonitorExtensionTest extends AbstractExtensionTestCase
     {
         parent::setUp();
 
-        $doctrineMock = $this->getMockBuilder('Doctrine\Common\Persistence\ConnectionRegistry')->getMock();
+        $doctrineMock = $this->getMockBuilder('Doctrine\Persistence\ConnectionRegistry')->getMock();
         $this->container->set('doctrine', $doctrineMock);
         $this->container->addCompilerPass(new AddGroupsCompilerPass());
         $this->container->addCompilerPass(new GroupRunnersCompilerPass());

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "symfony/templating": "^3.4 || ^4.0 || ^5.0",
         "phpunit/phpunit": "^7.0 || ^8.0",
         "symfony/finder": "^3.4 || ^4.0 || ^5.0",
-        "friendsofphp/php-cs-fixer": "^2.16"
+        "friendsofphp/php-cs-fixer": "^2.16",
+        "doctrine/persistence": "^1.3.3 || ^2.0"
     },
     "suggest": {
         "sensio/distribution-bundle": "To be able to use the composer ScriptHandler",


### PR DESCRIPTION
Liip monitor is using old class `Doctrine\Common\Persistence\ConnectionRegistry` for performing doctrine DBAL checks. This class has been moved to another namespace since `doctrine/persistence:^1.3`. 

This PR fixes old namespace and lets the liip monitor bundle work with both 1.3.x and 2.x branches of `doctrine/persistence`.