### PR TITLE
Using the `getConfiguration` method in the LiipMonitorExtension class

### DIFF
--- a/DependencyInjection/LiipMonitorExtension.php
+++ b/DependencyInjection/LiipMonitorExtension.php
@@ -51,7 +51,7 @@ class LiipMonitorExtension extends Extension implements CompilerPassInterface
         $loader->load('helper.xml');
         $loader->load('commands.xml');
 
-        $configuration = new Configuration();
+        $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
         if (null === $config['view_template']) {


### PR DESCRIPTION
It would be great to have an opportunity to extend the LiipMonitorExtension class and add some new configuration.    

Unfortunately, there is only one way to extend the configuration of this bundle now. To achieve it we have to completely override the `Liip\MonitorBundle\DependencyInjection\LiipMonitorExtension::load` method.

Let's suppose that I want to add some new features to the bundle. I have `My\DependencyInjection\Configuration` like this:

```php
class Configuration implements ConfigurationInterface
{
    public function getConfigTreeBuilder(): TreeBuilder
    {
        $liipConfiguration = new LiipConfiguration();

        $liipTreeBuilder = $liipConfiguration->getConfigTreeBuilder();

        $liipTreeBuilder->getRootNode()
            ->children()
                ->scalarNode('my_config_parameter')->cannotBeEmpty()->end()
            ->end();

        return $liipTreeBuilder;
    }
}
```
The next step is to add this new config parameter to Extension. I would do something like that:

```php
class MyExtension extends LiipMonitorExtension
{
    public function load(array $configs, ContainerBuilder $container): void
    {
        parent::load($configs, $container);
        //my own logic here
    }

    public function getConfiguration(array $config, ContainerBuilder $container)
    {
        return new My\DependencyInjection\Configuration();
    }
}
```

But, unfortunately, it does not work, because the `Liip\MonitorBundle\DependencyInjection\Configuration` is instantiated explicitly in the `Liip\MonitorBundle\DependencyInjection\LiipMonitorExtension::load` method.