### PR TITLE
Replace abandoned Sensiolabs security checker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^3.0 || ^4.0",
-        "sensiolabs/security-checker": "^5.0 || ^6.0",
+        "enlightn/security-checker": "^1.2",
         "guzzlehttp/guzzle": "^5.3.2 || ^6.3.3 || ^7.0.1",
         "symfony/expression-language": "^3.4 || ^4.0 || ^5.0",
         "swiftmailer/swiftmailer": "^5.4 || ^6.1",


### PR DESCRIPTION
Replaces the abandoned [Sensiolabs security checker](https://github.com/sensiolabs/security-checker) with the [Enlightn security checker](https://github.com/enlightn/security-checker).