### PR TITLE
Allow Symfony 6, require PHP 7.3+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
       matrix:
         php: [7.4, 8.0]
         symfony: [4.4.*, 5.3.*, 5.4.*]
+        include:
+          - php: 8.0
+            symfony: 6.0.*
 
     steps:
       - name: Checkout code
@@ -54,7 +57,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.2
+          php-version: 7.3
           coverage: none
 
       - name: Install dependencies

--- a/composer.json
+++ b/composer.json
@@ -23,25 +23,24 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
-        "symfony/framework-bundle": "^4.4 || ^5.0",
-        "laminas/laminas-diagnostics": "^1.5"
+        "php": "^7.3 || ^8.0",
+        "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0",
+        "laminas/laminas-diagnostics": "^1.9"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
-        "sensiolabs/security-checker": "^5.0 || ^6.0",
         "enlightn/security-checker": "^1.2",
         "guzzlehttp/guzzle": "^5.3.2 || ^6.3.3 || ^7.0.1",
-        "symfony/expression-language": "^4.4 || ^5.0",
+        "symfony/expression-language": "^4.4 || ^5.0 || ^6.0",
         "swiftmailer/swiftmailer": "^5.4 || ^6.1",
         "doctrine/migrations": "^2.0 || ^3.0",
         "doctrine/doctrine-migrations-bundle": "^2.0 || ^3.0",
-        "symfony/twig-bundle": "^4.4 || ^5.0",
-        "symfony/browser-kit": "^4.4 || ^5.0",
-        "symfony/asset": "^4.4 || ^5.0",
-        "symfony/templating": "^4.4 || ^5.0",
+        "symfony/twig-bundle": "^4.4 || ^5.0 || ^6.0",
+        "symfony/browser-kit": "^4.4 || ^5.0 || ^6.0",
+        "symfony/asset": "^4.4 || ^5.0 || ^6.0",
+        "symfony/templating": "^4.4 || ^5.0 || ^6.0",
         "phpunit/phpunit": "^7.0 || ^8.0",
-        "symfony/finder": "^4.4 || ^5.0",
+        "symfony/finder": "^4.4 || ^5.0 || ^6.0",
         "friendsofphp/php-cs-fixer": "^2.16",
         "doctrine/persistence": "^1.3.3 || ^2.0"
     },


### PR DESCRIPTION
This PR does the following:
- Allows Symfony 6
- Bump `laminas/laminas-diagnostics` min version to 1.9
- Require PHP 7.3+
- Drop `sensiolabs/security-checker` dev dep

Blocked By:
- https://github.com/enlightn/security-checker/pull/26