### PR TITLE
Allow Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "symfony/framework-bundle": "^4.4 || ^5.0",
+        "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0",
         "laminas/laminas-diagnostics": "^1.5"
     },
     "require-dev": {


### PR DESCRIPTION
It seems it is necessary to add it here to be able to install it in new installations of symfony