### PR TITLE
Ensure PHP 8.1 support and modernize tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.4, 8.0]
+        php: [7.4, 8.0, 8.1]
         symfony: [4.4.*, 5.3.*, 5.4.*]
         include:
           - php: 8.0
+            symfony: 6.0.*
+          - php: 8.1
             symfony: 6.0.*
 
     steps:


### PR DESCRIPTION
Followup to #264.

Blockers:
- [ ] https://github.com/enlightn/security-checker/pull/26
- [x] https://github.com/laminas/laminas-diagnostics/pull/31