### PR TITLE
Fetaure/slug group routing

### DIFF
--- a/Controller/HealthCheckController.php
+++ b/Controller/HealthCheckController.php
@@ -174,7 +174,15 @@ class HealthCheckController
 
     private function getGroup(Request $request): string
     {
-        return $request->query->get('group') ?: $this->runnerManager->getDefaultGroup();
+         // from slug routing
+         if ($request->attributes->get('group')){
+            return $request->attributes->get('group');
+        }
+        else
+        {
+            //or from get URL parameter
+            return $request->query->get('group') ?: $this->runnerManager->getDefaultGroup();
+        }
     }
 
     public function listReportersAction(): JsonResponse

--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -9,6 +9,9 @@
     <route id="liip_monitor_list_checks" path="/checks">
         <default key="_controller">Liip\MonitorBundle\Controller\HealthCheckController::listAction</default>
     </route>
+    <route id="liip_monitor_list_checks_slug" path="/checks/group/{group}">
+        <default key="_controller">Liip\MonitorBundle\Controller\HealthCheckController::listAction</default>
+    </route>
     <route id="liip_monitor_list_all_checks" path="/all_checks">
         <default key="_controller">Liip\MonitorBundle\Controller\HealthCheckController::listAllAction</default>
     </route>
@@ -18,13 +21,25 @@
     <route id="liip_monitor_run_all_checks_http_status" path="/http_status_checks">
         <default key="_controller">Liip\MonitorBundle\Controller\HealthCheckController::runAllChecksHttpStatusAction</default>
     </route>
+    <route id="liip_monitor_run_all_checks_http_status_slug" path="/http_status_checks/group/{group}">
+        <default key="_controller">Liip\MonitorBundle\Controller\HealthCheckController::runAllChecksHttpStatusAction</default>
+    </route>
     <route id="liip_monitor_run_single_check_http_status" path="/http_status_check/{checkId}">
+        <default key="_controller">Liip\MonitorBundle\Controller\HealthCheckController::runSingleCheckHttpStatusAction</default>
+    </route>
+    <route id="liip_monitor_run_single_check_http_status_slug" path="/http_status_check/{checkId}/group/{group}">
         <default key="_controller">Liip\MonitorBundle\Controller\HealthCheckController::runSingleCheckHttpStatusAction</default>
     </route>
     <route id="liip_monitor_run_all_checks" path="/run">
         <default key="_controller">Liip\MonitorBundle\Controller\HealthCheckController::runAllChecksAction</default>
     </route>
+    <route id="liip_monitor_run_all_checks_slug" path="/run/group/{group}">
+        <default key="_controller">Liip\MonitorBundle\Controller\HealthCheckController::runAllChecksAction</default>
+    </route>
     <route id="liip_monitor_run_single_check" path="/run/{checkId}">
+        <default key="_controller">Liip\MonitorBundle\Controller\HealthCheckController::runSingleCheckAction</default>
+    </route>
+    <route id="liip_monitor_run_single_check_slug" path="/run/{checkId}/group/{group}">
         <default key="_controller">Liip\MonitorBundle\Controller\HealthCheckController::runSingleCheckAction</default>
     </route>
     <route id="liip_monitor_list_reporters" path="/list/reporters">

--- a/Resources/views/health/index.html.php
+++ b/Resources/views/health/index.html.php
@@ -208,7 +208,7 @@ $ curl -XPOST -H "Accept: application/json" <?php echo $request->getUriForPath($
             <dt><a href="<?php echo $request->getUriForPath($request->getPathInfo().'run?group='.$group); ?>"><?php echo $request->getPathInfo().'run?group='.$group; ?></a></dt>
             <dt><?php echo $request->getPathInfo().'run/check_id?group='.$group; ?></dt>
         </dl>
-        Or use slug URl /group/{group} to specify the check group:
+        Or use slug URL /group/{group} to specify the check group:
         <dl>
             <dt><a href="<?php echo $request->getUriForPath($request->getPathInfo().'checks/group/'.$group); ?>"><?php echo $request->getPathInfo().'checks/group/'.$group; ?></a></dt>
             <dt><a href="<?php echo $request->getUriForPath($request->getPathInfo().'http_status_checks/group/'.$group); ?>"><?php echo $request->getPathInfo().'http_status_checks/group/'.$group; ?></a></dt>

--- a/Resources/views/health/index.html.php
+++ b/Resources/views/health/index.html.php
@@ -208,7 +208,14 @@ $ curl -XPOST -H "Accept: application/json" <?php echo $request->getUriForPath($
             <dt><a href="<?php echo $request->getUriForPath($request->getPathInfo().'run?group='.$group); ?>"><?php echo $request->getPathInfo().'run?group='.$group; ?></a></dt>
             <dt><?php echo $request->getPathInfo().'run/check_id?group='.$group; ?></dt>
         </dl>
-
+        Or use slug URl /group/{group} to specify the check group:
+        <dl>
+            <dt><a href="<?php echo $request->getUriForPath($request->getPathInfo().'checks/group/'.$group); ?>"><?php echo $request->getPathInfo().'checks/group/'.$group; ?></a></dt>
+            <dt><a href="<?php echo $request->getUriForPath($request->getPathInfo().'http_status_checks/group/'.$group); ?>"><?php echo $request->getPathInfo().'http_status_checks/group/'.$group; ?></a></dt>
+            <dt><?php echo $request->getPathInfo().'http_status_check/check_id/group/'.$group; ?></dt>
+            <dt><a href="<?php echo $request->getUriForPath($request->getPathInfo().'run/group/'.$group); ?>"><?php echo $request->getPathInfo().'run/group/'.$group; ?></a></dt>
+            <dt><?php echo $request->getPathInfo().'run/check_id/group/'.$group; ?></dt>
+        </dl>
 </div>
 <?php echo $javascript; ?>
 </body>


### PR DESCRIPTION
Hi,
For my usage i need to use grouping check but unfortunately without GET parameter in url.
So i purpose my adds where grouping check can be use by a slug in route and too by GET method.

I updated the doc page with the new usage description like this example :
```
The following URLs accept an optional query parameter ?group= to specify the check group:

/monitor/health/checks?group=liveness
/monitor/health/http_status_checks?group=liveness
/monitor/health/http_status_check/check_id?group=liveness
/monitor/health/run?group=liveness
/monitor/health/run/check_id?group=liveness

Or use slug URL /group/{group} to specify the check group:

/monitor/health/checks/group/liveness
/monitor/health/http_status_checks/group/liveness
/monitor/health/http_status_check/check_id/group/liveness
/monitor/health/run/group/liveness
/monitor/health/run/check_id/group/liveness
```

Thanks for your job.