### PR TITLE
Register argument name aliases

### DIFF
--- a/DependencyInjection/Compiler/GroupRunnersCompilerPass.php
+++ b/DependencyInjection/Compiler/GroupRunnersCompilerPass.php
@@ -2,6 +2,7 @@
 
 namespace Liip\MonitorBundle\DependencyInjection\Compiler;
 
+use Liip\MonitorBundle\Runner;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -35,6 +36,7 @@ class GroupRunnersCompilerPass implements CompilerPassInterface
         $runners = [];
         foreach ($groups as $group) {
             $container->setDefinition('liip_monitor.runner_'.$group, clone $definition);
+            $container->registerAliasForArgument('liip_monitor.runner_' . $group, Runner::class, $group . 'Runner');
             $runners[] = 'liip_monitor.runner_'.$group;
         }
 
@@ -48,7 +50,7 @@ class GroupRunnersCompilerPass implements CompilerPassInterface
     private function getGroups(array $services): array
     {
         $groups = [];
-        foreach ($services as $serviceId => $tags) {
+        foreach ($services as $tags) {
             foreach ($tags as $attributes) {
                 if (!empty($attributes['group'])) {
                     $groups[$attributes['group']] = true;

--- a/DependencyInjection/Compiler/GroupRunnersCompilerPass.php
+++ b/DependencyInjection/Compiler/GroupRunnersCompilerPass.php
@@ -36,11 +36,12 @@ class GroupRunnersCompilerPass implements CompilerPassInterface
         $runners = [];
         foreach ($groups as $group) {
             $container->setDefinition('liip_monitor.runner_'.$group, clone $definition);
-            $container->registerAliasForArgument('liip_monitor.runner_' . $group, Runner::class, $group . 'Runner');
+            $container->registerAliasForArgument('liip_monitor.runner_'.$group, Runner::class, $group.'Runner');
             $runners[] = 'liip_monitor.runner_'.$group;
         }
 
         $container->setAlias('liip_monitor.runner', 'liip_monitor.runner_'.$defaultGroup);
+        $container->setAlias(Runner::class, 'liip_monitor.runner');
         $runner = $container->getAlias('liip_monitor.runner');
         $runner->setPublic(true);
 

--- a/Tests/DependencyInjection/Compiler/GroupRunnersCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/GroupRunnersCompilerPassTest.php
@@ -3,6 +3,7 @@
 namespace Liip\MonitorBundle\Tests\DependencyInjection\Compiler;
 
 use Liip\MonitorBundle\DependencyInjection\Compiler\GroupRunnersCompilerPass;
+use Liip\MonitorBundle\Runner;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -35,6 +36,11 @@ class GroupRunnersCompilerPassTest extends AbstractCompilerPassTestCase
         $this->assertContainerBuilderHasService('liip_monitor.runner_foobar');
         $this->assertContainerBuilderHasService('liip_monitor.runner_bar');
         $this->assertContainerBuilderHasService('liip_monitor.runner_baz');
+        $this->assertContainerBuilderHasAlias(Runner::class.' $fooRunner', 'liip_monitor.runner_foo');
+        $this->assertContainerBuilderHasAlias(Runner::class.' $foobarRunner', 'liip_monitor.runner_foobar');
+        $this->assertContainerBuilderHasAlias(Runner::class.' $barRunner', 'liip_monitor.runner_bar');
+        $this->assertContainerBuilderHasAlias(Runner::class.' $bazRunner', 'liip_monitor.runner_baz');
+        $this->assertContainerBuilderHasAlias(Runner::class.' $groupeParDéfautRunner', 'liip_monitor.runner_'.$defaultGroup);
     }
 
     protected function registerCompilerPass(ContainerBuilder $container): void

--- a/Tests/DependencyInjection/Compiler/GroupRunnersCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/GroupRunnersCompilerPassTest.php
@@ -41,6 +41,7 @@ class GroupRunnersCompilerPassTest extends AbstractCompilerPassTestCase
         $this->assertContainerBuilderHasAlias(Runner::class.' $barRunner', 'liip_monitor.runner_bar');
         $this->assertContainerBuilderHasAlias(Runner::class.' $bazRunner', 'liip_monitor.runner_baz');
         $this->assertContainerBuilderHasAlias(Runner::class.' $groupeParDéfautRunner', 'liip_monitor.runner_'.$defaultGroup);
+        $this->assertContainerBuilderHasAlias(Runner::class, 'liip_monitor.runner');
     }
 
     protected function registerCompilerPass(ContainerBuilder $container): void


### PR DESCRIPTION
Registers `Runner` services for each check group as named argument aliases. It is now possible to inject a specific runner into a controller or other service by naming the argument to match the group name:

```php
public function __construct(private Runner $fooRunner) {} // Injects liip_monitor.runner_foo

public function __construct(private Runner $defaultRunner) {} // Injects liip_monitor.runner_default

public function __construct(private Runner $runner) {} // Injects liip_monitor.runner (alias of liip_monitor.runner_default)
```

This is a common practice in Symfony world, used for example in `symfony/http-client` or `league/flysystem-bundle`.