### PR TITLE
Update dependencies, improve mailer test

### DIFF
--- a/Tests/Helper/SymfonyMailerReporterTest.php
+++ b/Tests/Helper/SymfonyMailerReporterTest.php
@@ -21,10 +21,6 @@ class SymfonyMailerReporterTest extends TestCase
 
     protected function setUp(): void
     {
-        if (!interface_exists(MailerInterface::class)) {
-            $this->markTestSkipped('Symfony Mailer not available.');
-        }
-
         $this->mailer = $this->createMock(MailerInterface::class);
     }
 
@@ -35,16 +31,16 @@ class SymfonyMailerReporterTest extends TestCase
     {
         $reporter = new SymfonyMailerReporter($this->mailer, $recipients, $sender, $subject);
 
-        $check = $this->prophesize(CheckInterface::class);
-        $check->getLabel()->willReturn('Some Label');
+        $check = $this->createStub(CheckInterface::class);
+        $check->method('getLabel')->willReturn('Some Label');
 
         $checks = new Collection();
-        $checks[$check->reveal()] = new Failure('Something goes wrong');
+        $checks[$check] = new Failure('Something goes wrong');
 
         $this->mailer
             ->expects(self::once())
             ->method('send')
-            ->with(self::callback(function (?Email $message) use ($recipients, $sender, $subject): bool {
+            ->with(self::callback(static function (Email $message) use ($recipients, $sender, $subject): bool {
                 self::assertEquals(Address::createArray($recipients), $message->getTo(), 'Check if Recipient is sent correctly.');
                 self::assertEquals([Address::create($sender)], $message->getFrom(), 'Check that the from header is set correctly.');
                 self::assertSame($subject, $message->getSubject(), 'Check that the subject has been set.');

--- a/composer.json
+++ b/composer.json
@@ -39,13 +39,13 @@
         "symfony/browser-kit": "^4.4 || ^5.0 || ^6.0",
         "symfony/asset": "^4.4 || ^5.0 || ^6.0",
         "symfony/templating": "^4.4 || ^5.0 || ^6.0",
-        "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+        "symfony/mailer": "^4.4 || ^5.0 || ^6.0",
+        "phpunit/phpunit": "^9.0",
         "symfony/finder": "^4.4 || ^5.0 || ^6.0",
         "friendsofphp/php-cs-fixer": "^3.4",
-        "doctrine/persistence": "^1.3.3 || ^2.0"
+        "doctrine/persistence": "^1.3.3 || ^2.0 || ^3.0"
     },
     "suggest": {
-        "sensio/distribution-bundle": "To be able to use the composer ScriptHandler",
         "symfony/expression-language": "To use the Expression check"
     },
     "autoload": {


### PR DESCRIPTION
- Since the bundle already requires Symfony 4.4, we can require-dev `symfony/mailer`.
- `sensio/distribution-bundle` suggestion has been dropped because it is deprecated and no longer applicable in Symfony 4.4+
- Usage of deprecated `prophesize()` has been removed
- PHPUnit has been bumped to v9 as we already require PHP 7.3+