### PR TITLE
Feature: Built-in check for Symfony Messenger queue size 

### DIFF
--- a/Check/SymfonyMessengerTransportCount.php
+++ b/Check/SymfonyMessengerTransportCount.php
@@ -23,6 +23,10 @@ class SymfonyMessengerTransportCount extends AbstractCheck
 
         $this->warningThreshold = $config['warning_threshold'];
         $this->criticalThreshold = $config['critical_threshold'];
+
+        if ($this->warningThreshold && $this->warningThreshold >= $this->criticalThreshold) {
+            throw new \LogicException('Warning threshold must be lower than critical threshold');
+        }
     }
 
     public function check()

--- a/Check/SymfonyMessengerTransportCount.php
+++ b/Check/SymfonyMessengerTransportCount.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Liip\MonitorBundle\Check;
+
+use Laminas\Diagnostics\Check\AbstractCheck;
+use Laminas\Diagnostics\Result\Failure;
+use Laminas\Diagnostics\Result\Success;
+use Laminas\Diagnostics\Result\Warning;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
+
+class SymfonyMessengerTransportCount extends AbstractCheck
+{
+    private $transport;
+    private $transportName;
+
+    private $warningThreshold;
+    private $criticalThreshold;
+
+    public function __construct(MessageCountAwareInterface $transport, string $transportName, array $config)
+    {
+        $this->transport = $transport;
+        $this->transportName = $transportName;
+
+        $this->warningThreshold = $config['warning_threshold'];
+        $this->criticalThreshold = $config['critical_threshold'];
+    }
+
+    public function check()
+    {
+        $count = $this->transport->getMessageCount();
+
+        if ($count >= $this->criticalThreshold) {
+            return new Failure(sprintf('Critical: count of messages (%d) in transport "%s" exceeds limit', $count, $this->transportName));
+        }
+        if ($this->warningThreshold && $count >= $this->warningThreshold) {
+            return new Warning(sprintf('Warning: count of messages (%d) in transport "%s" exceeds limit', $count, $this->transportName));
+        }
+
+        return new Success(sprintf('Message count (%d) in "%s" expected range', $count, $this->transportName));
+    }
+}

--- a/Check/SymfonyMessengerTransportCountCollection.php
+++ b/Check/SymfonyMessengerTransportCountCollection.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Liip\MonitorBundle\Check;
+
+use Laminas\Diagnostics\Check\CheckCollectionInterface;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
+
+class SymfonyMessengerTransportCountCollection implements CheckCollectionInterface
+{
+    public const SERVICE_ID_PREFIX = 'messenger.transport.';
+
+    /**
+     * @var ServiceLocator
+     */
+    private $messengerLocator;
+
+    /**
+     * @var array
+     */
+    private $transports;
+
+    public function __construct(ServiceLocator $messengerReceiverLocator, array $transportConfig)
+    {
+        $this->messengerLocator = $messengerReceiverLocator;
+        $this->transports = $transportConfig;
+    }
+
+    public function getChecks()
+    {
+        $checks = [];
+        foreach ($this->transports as $transportName => $config) {
+            $serviceId = $config['service'] ?? self::SERVICE_ID_PREFIX.$transportName;
+            if (!$this->messengerLocator->has($serviceId)) {
+                throw new ServiceNotFoundException($serviceId);
+            }
+            $transport = $this->messengerLocator->get($serviceId);
+            if (!$transport instanceof MessageCountAwareInterface) {
+                throw new \Exception(sprintf('Cannot use transport "%s" for check, it does not implement MessageCountAwareInterface', $transportName));
+            }
+            $checks[sprintf('messenger_transport_%s', $transportName)] = new SymfonyMessengerTransportCount($transport, $transportName, $config);
+        }
+
+        return $checks;
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -395,16 +395,17 @@ class Configuration implements ConfigurationInterface
                         ->info('Symfony messenger transports to check count')
                         ->example([
                             'default' => [
-                                'foo' => 'messenger.transport.foo',
-                                'warning_threshold' => 10,
                                 'critical_threshold' => 100,
+                                'warning_threshold' => 10,
+                                'service' => 'messenger.transport.foo',
                             ],
                         ])
                         ->useAttributeAsKey('name')
                         ->prototype('array')
                             ->children()
-                                ->integerNode('warning_threshold')->defaultNull()->end()
                                 ->integerNode('critical_threshold')->isRequired()->end()
+                                ->integerNode('warning_threshold')->defaultNull()->end()
+                                ->scalarNode('service')->defaultNull()->end()
                             ->end()
                         ->end()
                     ->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -391,6 +391,23 @@ class Configuration implements ConfigurationInterface
                             ->end()
                         ->end()
                     ->end()
+                    ->arrayNode('messenger_transports')
+                        ->info('Symfony messenger transports to check count')
+                        ->example([
+                            'default' => [
+                                'foo' => 'messenger.transport.foo',
+                                'warning_threshold' => 10,
+                                'critical_threshold' => 100,
+                            ],
+                        ])
+                        ->useAttributeAsKey('name')
+                        ->prototype('array')
+                            ->children()
+                                ->integerNode('warning_threshold')->defaultNull()->end()
+                                ->integerNode('critical_threshold')->isRequired()->end()
+                            ->end()
+                        ->end()
+                    ->end()
                     ->arrayNode('expressions')
                         ->useAttributeAsKey('alias')
                         ->info('Checks that fail/warn when given expression is false (expressions are evaluated with symfony/expression-language)')

--- a/DependencyInjection/LiipMonitorExtension.php
+++ b/DependencyInjection/LiipMonitorExtension.php
@@ -133,9 +133,9 @@ class LiipMonitorExtension extends Extension implements CompilerPassInterface
             case 'file_yaml':
             case 'expressions':
             case 'pdo_connections':
+            case 'messenger_transports':
                 $container->setParameter($prefix.'.'.$group, $values);
                 break;
-
             case 'symfony_version':
             case 'opcache_memory':
                 break;

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Liip Monitor Bundle #
 
 [![CI Status](https://github.com/liip/LiipMonitorBundle/workflows/CI/badge.svg)](https://github.com/liip/LiipMonitorBundle/actions?query=workflow%3ACI)
@@ -468,6 +469,14 @@ liip_monitor:
                         critical_expression:  null # Example: ini('short_open_tag') == 1
                         warning_message:      null
                         critical_message:     null
+
+                # Validate that a messenger transport does not contain more than warning/critical messages
+                # Transport must implement MessageCountAwareInterface
+                messenger_transport:
+                    name: # name of transport
+                        critical_threshold:   10   # required
+                        warning_threshold:    null # optional: warning level
+                        service:              null # defaults to messenger.transport.name 
 ```
 
 ## REST API DOCS ##

--- a/Resources/config/checks/messenger_transports.xml
+++ b/Resources/config/checks/messenger_transports.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="liip_monitor.check.messenger_transports" public="true" class="Liip\MonitorBundle\Check\SymfonyMessengerTransportCountCollection">
+            <argument type="service" id="messenger.receiver_locator" />
+            <argument>%%liip_monitor.check.messenger_transports%%</argument>
+            <tag name="liip_monitor.check_collection" />
+        </service>
+    </services>
+</container>

--- a/Tests/Check/SymfonyMessengerTransportCountTest.php
+++ b/Tests/Check/SymfonyMessengerTransportCountTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Check;
+
+use Laminas\Diagnostics\Result\Failure;
+use Laminas\Diagnostics\Result\Success;
+use Laminas\Diagnostics\Result\Warning;
+use Liip\MonitorBundle\Check\SymfonyMessengerTransportCount;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
+
+class SymfonyMessengerTransportCountTest extends TestCase
+{
+    public function testLogicExceptionWhenCriticalLowerThenWarning()
+    {
+        $this->expectException(\LogicException::class);
+        new SymfonyMessengerTransportCount(
+            $this->getMockBuilder(MessageCountAwareInterface::class)->getMock(),
+            'foo',
+            ['warning_threshold' => 2, 'critical_threshold' => 1]
+        );
+    }
+
+    /**
+     * @dataProvider checkResultProvider
+     */
+    public function testCheckResult($config, $count, $expectedResult)
+    {
+        $transport = $this->getMockBuilder(MessageCountAwareInterface::class)->getMock();
+        $transport->method('getMessageCount')->will($this->returnValue($count));
+
+        $check = new SymfonyMessengerTransportCount(
+            new Transport($count),
+            'foo',
+            $config
+        );
+        $this->assertInstanceOf($expectedResult, $check->check());
+    }
+
+    public function checkResultProvider()
+    {
+        return [
+            [['warning_threshold' => null, 'critical_threshold' => 1], 0, Success::class],
+            [['warning_threshold' => 0, 'critical_threshold' => 1], 0, Success::class],
+            [['warning_threshold' => null, 'critical_threshold' => 0], 1, Failure::class],
+            [['warning_threshold' => 10, 'critical_threshold' => 100], 9, Success::class],
+            [['warning_threshold' => 10, 'critical_threshold' => 100], 10, Warning::class],
+            [['warning_threshold' => 10, 'critical_threshold' => 100], 99, Warning::class],
+            [['warning_threshold' => 10, 'critical_threshold' => 100], 100, Failure::class],
+        ];
+    }
+}
+
+class Transport implements MessageCountAwareInterface
+{
+    private $n;
+
+    public function __construct(int $n)
+    {
+        $this->n = $n;
+    }
+
+    public function getMessageCount(): int
+    {
+        return $this->n;
+    }
+}

--- a/Tests/DependencyInjection/LiipMonitorExtensionTest.php
+++ b/Tests/DependencyInjection/LiipMonitorExtensionTest.php
@@ -265,6 +265,7 @@ class LiipMonitorExtensionTest extends AbstractExtensionTestCase
             [['foo']], // missing critical_threshold
             [['foo' => ['critical_threshold' => '1']]], // critical_threshold not int
             [['foo' => ['critical_threshold' => 2, 'warning_threshold' => '1']]], // warning_threshold not int
+            [['foo' => ['critical_threshold' => 2, 'warning_threshold' => 1, 'service' => []]]], // service not scalar
         ];
     }
 
@@ -309,6 +310,7 @@ class LiipMonitorExtensionTest extends AbstractExtensionTestCase
             ['messenger_transports', ['foo' => ['critical_threshold' => 100]], SymfonyMessengerTransportCount::class, 'messenger_transport_foo', 1],
             ['messenger_transports', ['foo' => ['critical_threshold' => 100], 'bar' => ['critical_threshold' => 1]], SymfonyMessengerTransportCount::class, 'messenger_transport_foo', 2],
             ['messenger_transports', ['foo' => ['critical_threshold' => 100], 'bar' => ['critical_threshold' => 1]], SymfonyMessengerTransportCount::class, 'messenger_transport_bar', 2],
+            ['messenger_transports', ['foo' => ['critical_threshold' => 100, 'service' => 'messenger.transport.foo'], 'bar' => ['critical_threshold' => 1, 'service' => 'messenger.transport.foo']], SymfonyMessengerTransportCount::class, 'messenger_transport_bar', 2],
         ];
     }
 

--- a/Tests/DependencyInjection/LiipMonitorExtensionTest.php
+++ b/Tests/DependencyInjection/LiipMonitorExtensionTest.php
@@ -29,6 +29,7 @@ use Laminas\Diagnostics\Check\YamlFile;
 use Liip\MonitorBundle\Check\CustomErrorPages;
 use Liip\MonitorBundle\Check\DoctrineDbal;
 use Liip\MonitorBundle\Check\Expression;
+use Liip\MonitorBundle\Check\SymfonyMessengerTransportCount;
 use Liip\MonitorBundle\Check\SymfonyVersion;
 use Liip\MonitorBundle\DependencyInjection\Compiler\AddGroupsCompilerPass;
 use Liip\MonitorBundle\DependencyInjection\Compiler\CheckCollectionTagCompilerPass;
@@ -37,6 +38,8 @@ use Liip\MonitorBundle\DependencyInjection\Compiler\GroupRunnersCompilerPass;
 use Liip\MonitorBundle\DependencyInjection\LiipMonitorExtension;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -49,6 +52,21 @@ class LiipMonitorExtensionTest extends AbstractExtensionTestCase
 
         $doctrineMock = $this->getMockBuilder('Doctrine\Persistence\ConnectionRegistry')->getMock();
         $this->container->set('doctrine', $doctrineMock);
+
+        $serviceLocator = $this->getMockBuilder(ServiceLocator::class)->disableOriginalConstructor()->getMock();
+        $serviceLocator->method('has')
+            ->will($this->returnValueMap([
+                ['messenger.transport.foo', true],
+                ['messenger.transport.bar', true],
+            ]));
+        $serviceLocator->method('get')
+            ->will($this->returnValueMap([
+                ['messenger.transport.foo', $this->getMockBuilder(MessageCountAwareInterface::class)->getMock()],
+                ['messenger.transport.bar', $this->getMockBuilder(MessageCountAwareInterface::class)->getMock()],
+            ]));
+
+        $this->container->set('messenger.receiver_locator', $serviceLocator);
+
         $this->container->addCompilerPass(new AddGroupsCompilerPass());
         $this->container->addCompilerPass(new GroupRunnersCompilerPass());
         $this->container->addCompilerPass(new CheckTagCompilerPass());
@@ -230,6 +248,26 @@ class LiipMonitorExtensionTest extends AbstractExtensionTestCase
         ];
     }
 
+    /**
+     * @dataProvider invalidMessengerTransportConfig
+     */
+    public function testInvalidMessengerTransportConfig(array $config): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+
+        $this->load(['checks' => ['messenger_transports' => $config]]);
+        $this->compile();
+    }
+
+    public function invalidMessengerTransportConfig(): array
+    {
+        return [
+            [['foo']], // missing critical_threshold
+            [['foo' => ['critical_threshold' => '1']]], // critical_threshold not int
+            [['foo' => ['critical_threshold' => 2, 'warning_threshold' => '1']]], // warning_threshold not int
+        ];
+    }
+
     public function checkProvider(): array
     {
         return [
@@ -268,6 +306,9 @@ class LiipMonitorExtensionTest extends AbstractExtensionTestCase
             ['file_yaml', ['foo.yaml'], YamlFile::class],
             ['expressions', ['foo' => ['label' => 'foo', 'critical_expression' => 'true']], Expression::class, 'expression_foo'],
             ['pdo_connections', ['foo' => ['dsn' => 'my-dsn']], PDOCheck::class, 'pdo_foo'],
+            ['messenger_transports', ['foo' => ['critical_threshold' => 100]], SymfonyMessengerTransportCount::class, 'messenger_transport_foo', 1],
+            ['messenger_transports', ['foo' => ['critical_threshold' => 100], 'bar' => ['critical_threshold' => 1]], SymfonyMessengerTransportCount::class, 'messenger_transport_foo', 2],
+            ['messenger_transports', ['foo' => ['critical_threshold' => 100], 'bar' => ['critical_threshold' => 1]], SymfonyMessengerTransportCount::class, 'messenger_transport_bar', 2],
         ];
     }
 

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "phpunit/phpunit": "^9.0",
         "symfony/finder": "^4.4 || ^5.0 || ^6.0",
         "friendsofphp/php-cs-fixer": "^3.4",
-        "doctrine/persistence": "^1.3.3 || ^2.0 || ^3.0"
+        "doctrine/persistence": "^1.3.3 || ^2.0 || ^3.0",
+        "symfony/messenger": "^6.2"
     },
     "suggest": {
         "symfony/expression-language": "To use the Expression check"

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "symfony/finder": "^4.4 || ^5.0 || ^6.0",
         "friendsofphp/php-cs-fixer": "^3.4",
         "doctrine/persistence": "^1.3.3 || ^2.0 || ^3.0",
-        "symfony/messenger": "^6.2"
+        "symfony/messenger": "^4.4|^5.4|^6.0"
     },
     "suggest": {
         "symfony/expression-language": "To use the Expression check"


### PR DESCRIPTION
This adds the ability to configure checks, that ensure that the count of messages in Symfony Messenger transports does not exceed expected limits. It uses [MessageCountAwareInterface](https://github.com/symfony/messenger/blob/6.2/Transport/Receiver/MessageCountAwareInterface.php) and therefore only works for transports that implement that interface.

Dear maintainers, we implemented similar checks in several projects. I've now ported that into a feature on library level. Please let me know, if you don't consider it as in scope of this project or if i need to add/change anything before it can be merged.