### PR TITLE
Amended reporters to no longer throw non-scalar value within symfony6

### DIFF
--- a/Controller/HealthCheckController.php
+++ b/Controller/HealthCheckController.php
@@ -139,7 +139,7 @@ class HealthCheckController
      */
     protected function runTests(Request $request, $checkId = null): ArrayReporter
     {
-        $reporters = $request->query->get('reporters') ?? [];
+        $reporters = $request->query->all('reporters') ?? [];
 
         if (!is_array($reporters)) {
             $reporters = [$reporters];


### PR DESCRIPTION
Currently when trying to add a reporter within the config in symfony6 I was dealt with the error 'Input value "reporters" contains a non-scalar value.'
I found that changing 
$reporters = $request->query->get('reporters') ?? []; 
to 
$reporters = $request->query->all('reporters') ?? [];
resolved this issue.

 