### PR TITLE
Use the Extension class of symfony/dependency-injection instead of sy…

### DIFF
--- a/DependencyInjection/LiipMonitorExtension.php
+++ b/DependencyInjection/LiipMonitorExtension.php
@@ -7,8 +7,8 @@ use Liip\MonitorBundle\DependencyInjection\DoctrineMigrations\DoctrineMigrations
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class LiipMonitorExtension extends Extension implements CompilerPassInterface
 {


### PR DESCRIPTION
Switch from Symfony\Component\HttpKernel\DependencyInjection\Extension which is internal in Symfony 7.1 to Symfony\Component\DependencyInjection\Extension\Extension which may be used instead:
https://github.com/symfony/symfony/commit/ef9592868d80d95f3cad038d403ead40b0f70e87