### PR TITLE
feat: open up versions phpunit and enlightn/security-checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,6 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - php: 8.1
-            symfony: 6.4.*
-          - php: 8.2
-            symfony: 6.4.*
           - php: 8.2
             symfony: 7.2.*
           - php: 8.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,18 +16,22 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - php: 7.4
-            symfony: 5.4.*
-          - php: 8.0
-            symfony: 5.4.*
           - php: 8.1
             symfony: 6.4.*
           - php: 8.2
             symfony: 6.4.*
           - php: 8.2
-            symfony: 7.0.*
+            symfony: 7.2.*
+          - php: 8.2
+            symfony: 7.3.*
           - php: 8.3
-            symfony: 7.0.*
+            symfony: 7.2.*
+          - php: 8.3
+            symfony: 7.3.*
+          - php: 8.4
+            symfony: 7.2.*
+          - php: 8.4
+            symfony: 7.3.*
 
     steps:
       - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "friendsofphp/php-cs-fixer": "^3.4",
         "doctrine/persistence": "^1.3.3 || ^2.0 || ^3.0",
         "symfony/messenger": "^5.4 ||^6.0 || ^7.0",
-        "symfony/mime": "^5.4 ||^6.0 || ^7.0 || ^7.3"
+        "symfony/mime": "^5.4 ||^6.0 || ^7.0 || ^7.2 || ^7.3 || ^8.0"
     },
     "suggest": {
         "symfony/expression-language": "To use the Expression check"

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "symfony/finder": "^5.4 || ^6.0 || ^7.0",
         "friendsofphp/php-cs-fixer": "^3.4",
         "doctrine/persistence": "^1.3.3 || ^2.0 || ^3.0",
-        "symfony/messenger": "^5.4 ||^6.0 || ^7.0"
+        "symfony/messenger": "^5.4 ||^6.0 || ^7.0",
+        "symfony/mime": "^7.2"
     },
     "suggest": {
         "symfony/expression-language": "To use the Expression check"

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^4.3 || ^5.0",
-        "enlightn/security-checker": "^1.11",
+        "enlightn/security-checker": "^1.11|^2.0",
         "guzzlehttp/guzzle": "^5.3.2 || ^6.3.3 || ^7.0.1",
         "symfony/expression-language": "^5.4 || ^6.0 || ^7.0",
         "swiftmailer/swiftmailer": "^5.4 || ^6.1 || ^7.0",
@@ -40,7 +40,7 @@
         "symfony/asset": "^5.4 || ^6.0 || ^7.0",
         "symfony/templating": "^5.4 || ^6.0 || ^7.0",
         "symfony/mailer": "^5.4 || ^6.0 || ^7.0",
-        "phpunit/phpunit": "^9.0",
+        "phpunit/phpunit": "^9.0|^10.0",
         "symfony/finder": "^5.4 || ^6.0 || ^7.0",
         "friendsofphp/php-cs-fixer": "^3.4",
         "doctrine/persistence": "^1.3.3 || ^2.0 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "friendsofphp/php-cs-fixer": "^3.4",
         "doctrine/persistence": "^1.3.3 || ^2.0 || ^3.0",
         "symfony/messenger": "^5.4 ||^6.0 || ^7.0",
-        "symfony/mime":"^6.2 || ^7.2 || ^7.3"
+        "symfony/mime": "^5.4 ||^6.0 || ^7.0 || ^7.3"
     },
     "suggest": {
         "symfony/expression-language": "To use the Expression check"

--- a/composer.json
+++ b/composer.json
@@ -39,13 +39,13 @@
         "symfony/browser-kit": "^5.4 || ^6.0 || ^7.0",
         "symfony/asset": "^5.4 || ^6.0 || ^7.0",
         "symfony/templating": "^5.4 || ^6.0 || ^7.0",
-        "symfony/mailer": "^5.4 || ^6.0 || ^7.0",
+        "symfony/mailer": "^5.4 || ^6.0 || ^7.0 || ^7.3",
         "phpunit/phpunit": "^9.0|^10.0",
         "symfony/finder": "^5.4 || ^6.0 || ^7.0",
         "friendsofphp/php-cs-fixer": "^3.4",
         "doctrine/persistence": "^1.3.3 || ^2.0 || ^3.0",
         "symfony/messenger": "^5.4 ||^6.0 || ^7.0",
-        "symfony/mime": "^7.2 || ^6.2"
+        "symfony/mime":"^6.2 || ^7.2 || ^7.3"
     },
     "suggest": {
         "symfony/expression-language": "To use the Expression check"

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "friendsofphp/php-cs-fixer": "^3.4",
         "doctrine/persistence": "^1.3.3 || ^2.0 || ^3.0",
         "symfony/messenger": "^5.4 ||^6.0 || ^7.0",
-        "symfony/mime": "^7.2|^6.2"
+        "symfony/mime": "^7.2 || ^6.2"
     },
     "suggest": {
         "symfony/expression-language": "To use the Expression check"

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "friendsofphp/php-cs-fixer": "^3.4",
         "doctrine/persistence": "^1.3.3 || ^2.0 || ^3.0",
         "symfony/messenger": "^5.4 ||^6.0 || ^7.0",
-        "symfony/mime": "^7.2"
+        "symfony/mime": "^7.2|^6.2"
     },
     "suggest": {
         "symfony/expression-language": "To use the Expression check"


### PR DESCRIPTION
This allows to update the packages with PHP 8.4 version without conflicts


For example it resolves:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires liip/monitor-bundle 2.23.2 -> satisfiable by liip/monitor-bundle[2.23.2].
    - laminas/laminas-diagnostics[1.9.0, ..., 1.11.x-dev] require php ^7.3 || ~8.0.0 -> your php version (8.4.6) does not satisfy that requirement.
    - laminas/laminas-diagnostics[1.12.0, ..., 1.19.x-dev] require php ^7.4 || ~8.0.0 || ~8.1.0 -> your php version (8.4.6) does not satisfy that requirement.
    - laminas/laminas-diagnostics[1.20.0, ..., 1.22.x-dev] require php ^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0 -> your php version (8.4.6) does not satisfy that requirement.
    - laminas/laminas-diagnostics[1.23.0, ..., 1.24.x-dev] require php ~8.0.0 || ~8.1.0 || ~8.2.0 -> your php version (8.4.6) does not satisfy that requirement.
    - laminas/laminas-diagnostics[1.25.0, ..., 1.26.x-dev] require php ~8.1.0 || ~8.2.0 || ~8.3.0 -> your php version (8.4.6) does not satisfy that requirement.
    - laminas/laminas-diagnostics[1.27.0, ..., 1.28.x-dev] require enlightn/security-checker ^1.10 -> found enlightn/security-checker[v1.10.0, v1.11.0, 1.x-dev] but it conflicts with your temporary update constraint (enlightn/security-checker:^2.0.0).
    - liip/monitor-bundle 2.23.2 requires laminas/laminas-diagnostics ^1.9 -> satisfiable by laminas/laminas-diagnostics[1.9.0, ..., 1.28.x-dev].
```


```
composer why enlightn/security-checker
laminas/laminas-diagnostics 1.27.0 requires enlightn/security-checker (^1.10) 
```

```
composer why laminas/laminas-diagnostics
liip/monitor-bundle 2.23.2 requires laminas/laminas-diagnostics (^1.9) 
```

```
composer why liip/monitor-bundle
__root__ dev-develop requires liip/monitor-bundle (2.23.2) 
```