### PR TITLE
fix: configured label was not being used in ping check

### DIFF
--- a/src/Check/PingUrlCheck.php
+++ b/src/Check/PingUrlCheck.php
@@ -138,7 +138,7 @@ final class PingUrlCheck implements Check, ConfigurableCheck, \Stringable
     public static function load(array $config, ContainerBuilder $container): void
     {
         foreach ($config as $key => $check) {
-            $check['label'] = $check['label'] ?? \is_string($key) ? $key : null;
+            $check['label'] = $check['label'] ?? (\is_string($key) ? $key : null);
 
             $container->register(\sprintf('.liip_monitor.check.ping_url.%s', $key), self::class)
                 ->setArguments([


### PR DESCRIPTION
When setting a label for a ping check it would come out as 0,1,2,3... instead of the label.
