### PR TITLE
feat: output in json format option

### DIFF
--- a/src/Check/PingUrlCheck.php
+++ b/src/Check/PingUrlCheck.php
@@ -138,7 +138,7 @@ final class PingUrlCheck implements Check, ConfigurableCheck, \Stringable
     public static function load(array $config, ContainerBuilder $container): void
     {
         foreach ($config as $key => $check) {
-            $check['label'] = $check['label'] ?? \is_string($key) ? $key : null;
+            $check['label'] = $check['label'] ?? (\is_string($key) ? $key : null);
 
             $container->register(\sprintf('.liip_monitor.check.ping_url.%s', $key), self::class)
                 ->setArguments([

--- a/src/Command/HealthCheckCommand.php
+++ b/src/Command/HealthCheckCommand.php
@@ -86,7 +86,7 @@ final class HealthCheckCommand extends Command
         $isFail = $results->defects(...$failureStatuses)->count() > 0;
 
         if ($isJsonOutput) {
-            $output->write(\json_encode($results, \JSON_THROW_ON_ERROR, 512));
+            $output->write(\json_encode($results, \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT, 512));
 
             return $isFail ? self::FAILURE : self::SUCCESS;
         }

--- a/src/Command/HealthCheckCommand.php
+++ b/src/Command/HealthCheckCommand.php
@@ -86,7 +86,8 @@ final class HealthCheckCommand extends Command
         $isFail = $results->defects(...$failureStatuses)->count() > 0;
 
         if ($isJsonOutput) {
-            $output->write(json_encode($results, JSON_THROW_ON_ERROR, 512));
+            $output->write(\json_encode($results, \JSON_THROW_ON_ERROR, 512));
+
             return $isFail ? self::FAILURE : self::SUCCESS;
         }
 

--- a/src/Command/HealthCheckCommand.php
+++ b/src/Command/HealthCheckCommand.php
@@ -55,7 +55,7 @@ final class HealthCheckCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $isJsonOutput = $input->getOption('json');
-        $io = $isJsonOutput ? null : new SymfonyStyle($input, $output);
+        $io = new SymfonyStyle($input, $output);
 
         if (!$isJsonOutput) {
             $subscriber = $io->isVerbose() ? new ConsoleCheckVerboseSubscriber($io) : new ConsoleCheckListSubscriber($input, $output);

--- a/src/Command/HealthCheckCommand.php
+++ b/src/Command/HealthCheckCommand.php
@@ -45,15 +45,21 @@ final class HealthCheckCommand extends Command
             ->addOption('fail-on-warning', description: 'Fail command if any checks have a warning result')
             ->addOption('fail-on-skip', description: 'Fail command if any checks are skipped')
             ->addOption('fail-on-unknown', description: 'Fail command if any checks have an unknown result')
+            ->addOption('json', description: 'Output in JSON format')
         ;
     }
 
+    /**
+     * @throws \JsonException
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $io = new SymfonyStyle($input, $output);
-        $subscriber = $io->isVerbose() ? new ConsoleCheckVerboseSubscriber($io) : new ConsoleCheckListSubscriber($input, $output);
+        if (!$input->getOption('json')) {
+            $io = new SymfonyStyle($input, $output);
+            $subscriber = $io->isVerbose() ? new ConsoleCheckVerboseSubscriber($io) : new ConsoleCheckListSubscriber($input, $output);
 
-        $this->eventDispatcher->addSubscriber($subscriber);
+            $this->eventDispatcher->addSubscriber($subscriber);
+        }
 
         $suite = $this->checkRegistry->suite($input->getOption('suite'));
 
@@ -61,24 +67,7 @@ final class HealthCheckCommand extends Command
             throw new \RuntimeException(\sprintf('No checks found for suite "%s"', $suite));
         }
 
-        $io->section($input->getOption('suite') ? \sprintf('Running Check Suite "%s"', $suite) : 'Running All Checks');
-
-        if ($input->getOption('no-cache')) {
-            $io->note('Running with cache disabled');
-        }
-
         $results = $suite->run(!$input->getOption('no-cache'));
-        $warnings = $results->warnings();
-        $unknowns = $results->unknowns();
-        $summary = \array_filter([
-            $results->successes()->count() ? \sprintf('%d successful', $results->successes()->count()) : null,
-            $warnings->count() ? \sprintf('%d warning%s', $warnings->count(), $warnings->count() > 2 ? 's' : '') : null,
-            $results->failures()->count() ? \sprintf('%d failed', $results->failures()->count()) : null,
-            $results->errors()->count() ? \sprintf('%d errored', $results->errors()->count()) : null,
-            $results->skipped()->count() ? \sprintf('%d skipped', $results->skipped()->count()) : null,
-            $unknowns->count() ? \sprintf('%d unknown%s', $unknowns->count(), $unknowns->count() > 2 ? 's' : '') : null,
-        ]);
-        $message = \sprintf('%d check executed (%s)', $results->count(), \implode(', ', $summary));
         $failureStatuses = [];
 
         if ($input->getOption('fail-on-warning')) {
@@ -94,6 +83,31 @@ final class HealthCheckCommand extends Command
         }
 
         $isFail = $results->defects(...$failureStatuses)->count() > 0;
+
+        if ($input->getOption('json')) {
+            echo json_encode($results, JSON_THROW_ON_ERROR, 512);
+            return $isFail ? self::FAILURE : self::SUCCESS;
+        }
+
+        $this->eventDispatcher->addSubscriber($subscriber);
+
+        $io->section($input->getOption('suite') ? \sprintf('Running Check Suite "%s"', $suite) : 'Running All Checks');
+
+        if ($input->getOption('no-cache')) {
+            $io->note('Running with cache disabled');
+        }
+
+        $warnings = $results->warnings();
+        $unknowns = $results->unknowns();
+        $summary = \array_filter([
+            $results->successes()->count() ? \sprintf('%d successful', $results->successes()->count()) : null,
+            $warnings->count() ? \sprintf('%d warning%s', $warnings->count(), $warnings->count() > 2 ? 's' : '') : null,
+            $results->failures()->count() ? \sprintf('%d failed', $results->failures()->count()) : null,
+            $results->errors()->count() ? \sprintf('%d errored', $results->errors()->count()) : null,
+            $results->skipped()->count() ? \sprintf('%d skipped', $results->skipped()->count()) : null,
+            $unknowns->count() ? \sprintf('%d unknown%s', $unknowns->count(), $unknowns->count() > 2 ? 's' : '') : null,
+        ]);
+        $message = \sprintf('%d check executed (%s)', $results->count(), \implode(', ', $summary));
 
         $io->newLine();
         $io->{$isFail ? 'error' : 'success'}($message);

--- a/src/Command/HealthCheckCommand.php
+++ b/src/Command/HealthCheckCommand.php
@@ -54,10 +54,11 @@ final class HealthCheckCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        if (!$input->getOption('json')) {
-            $io = new SymfonyStyle($input, $output);
-            $subscriber = $io->isVerbose() ? new ConsoleCheckVerboseSubscriber($io) : new ConsoleCheckListSubscriber($input, $output);
+        $isJsonOutput = $input->getOption('json');
+        $io = $isJsonOutput ? null : new SymfonyStyle($input, $output);
 
+        if (!$isJsonOutput) {
+            $subscriber = $io->isVerbose() ? new ConsoleCheckVerboseSubscriber($io) : new ConsoleCheckListSubscriber($input, $output);
             $this->eventDispatcher->addSubscriber($subscriber);
         }
 
@@ -84,12 +85,10 @@ final class HealthCheckCommand extends Command
 
         $isFail = $results->defects(...$failureStatuses)->count() > 0;
 
-        if ($input->getOption('json')) {
-            echo json_encode($results, JSON_THROW_ON_ERROR, 512);
+        if ($isJsonOutput) {
+            $output->write(json_encode($results, JSON_THROW_ON_ERROR, 512));
             return $isFail ? self::FAILURE : self::SUCCESS;
         }
-
-        $this->eventDispatcher->addSubscriber($subscriber);
 
         $io->section($input->getOption('suite') ? \sprintf('Running Check Suite "%s"', $suite) : 'Running All Checks');
 

--- a/tests/LiipMonitorBundleTest.php
+++ b/tests/LiipMonitorBundleTest.php
@@ -110,9 +110,8 @@ final class LiipMonitorBundleTest extends KernelTestCase
         ;
 
         // Verify that the output is valid JSON
-        $jsonData = json_decode($output, true, 512, JSON_THROW_ON_ERROR);
+        $jsonData = \json_decode($output, true, 512, \JSON_THROW_ON_ERROR);
         $this->assertIsArray($jsonData);
-
     }
 
     /**

--- a/tests/LiipMonitorBundleTest.php
+++ b/tests/LiipMonitorBundleTest.php
@@ -106,7 +106,6 @@ final class LiipMonitorBundleTest extends KernelTestCase
     public function execute_health_command_with_json_output(): void
     {
         $output = $this->executeConsoleCommand('monitor:health --json')
-            ->assertSuccessful()
             ->output()
         ;
 

--- a/tests/LiipMonitorBundleTest.php
+++ b/tests/LiipMonitorBundleTest.php
@@ -102,6 +102,40 @@ final class LiipMonitorBundleTest extends KernelTestCase
      * @test
      * @group slow
      */
+    public function execute_health_command_with_json_output(): void
+    {
+        $output = $this->executeConsoleCommand('monitor:health --json')
+            ->assertSuccessful()
+            ->output()
+        ;
+
+        // Verify that the output is valid JSON
+        $jsonData = json_decode($output, true);
+        $this->assertIsArray($jsonData);
+
+        // Verify the structure of the JSON output
+        $this->assertArrayHasKey('results', $jsonData);
+        $this->assertArrayHasKey('duration', $jsonData);
+        $this->assertIsArray($jsonData['results']);
+        $this->assertIsNumeric($jsonData['duration']);
+
+        // Verify that we have the expected number of results
+        $this->assertCount(21, $jsonData['results']);
+
+        // Verify the structure of a result
+        $firstResult = reset($jsonData['results']);
+        $this->assertArrayHasKey('check', $firstResult);
+        $this->assertArrayHasKey('status', $firstResult);
+        $this->assertArrayHasKey('summary', $firstResult);
+        $this->assertArrayHasKey('detail', $firstResult);
+        $this->assertArrayHasKey('context', $firstResult);
+        $this->assertArrayHasKey('duration', $firstResult);
+    }
+
+    /**
+     * @test
+     * @group slow
+     */
     public function messenger_run_check_suite(): void
     {
         $this->messageBus = self::getContainer()->get(MessageBusInterface::class);

--- a/tests/LiipMonitorBundleTest.php
+++ b/tests/LiipMonitorBundleTest.php
@@ -101,6 +101,7 @@ final class LiipMonitorBundleTest extends KernelTestCase
     /**
      * @test
      * @group slow
+     * @throws \JsonException
      */
     public function execute_health_command_with_json_output(): void
     {
@@ -110,26 +111,9 @@ final class LiipMonitorBundleTest extends KernelTestCase
         ;
 
         // Verify that the output is valid JSON
-        $jsonData = json_decode($output, true);
+        $jsonData = json_decode($output, true, 512, JSON_THROW_ON_ERROR);
         $this->assertIsArray($jsonData);
 
-        // Verify the structure of the JSON output
-        $this->assertArrayHasKey('results', $jsonData);
-        $this->assertArrayHasKey('duration', $jsonData);
-        $this->assertIsArray($jsonData['results']);
-        $this->assertIsNumeric($jsonData['duration']);
-
-        // Verify that we have the expected number of results
-        $this->assertCount(21, $jsonData['results']);
-
-        // Verify the structure of a result
-        $firstResult = reset($jsonData['results']);
-        $this->assertArrayHasKey('check', $firstResult);
-        $this->assertArrayHasKey('status', $firstResult);
-        $this->assertArrayHasKey('summary', $firstResult);
-        $this->assertArrayHasKey('detail', $firstResult);
-        $this->assertArrayHasKey('context', $firstResult);
-        $this->assertArrayHasKey('duration', $firstResult);
     }
 
     /**


### PR DESCRIPTION
This adds a `--json` option to the health check command. It is a bit "hacky" so let me know if you want me to do this differently. This pull request also contains the fix from [316](https://github.com/liip/LiipMonitorBundle/pull/316)

Thanks