### PR TITLE
remove branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,11 +52,6 @@
     "autoload": {
         "psr-4": { "Liip\\MonitorBundle\\": "" }
     },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "2.x-dev"
-        }
-    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }


### PR DESCRIPTION
we switched to semantic naming with each major version having a `#.x` branch name rather than a `master` or `main` branch.